### PR TITLE
Feature - Transaction contribution details

### DIFF
--- a/app/components/BackButton/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BackButton/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`back button renders correctly 1`] = `null`;

--- a/app/components/BackButton/__tests__/index-test.js
+++ b/app/components/BackButton/__tests__/index-test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BackButton from '../';
+import { MemoryRouter as Router } from 'react-router-dom'
+
+it('back button renders correctly', () => {
+  const tree = renderer.create(
+    <Router>
+      <BackButton />
+    </Router>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/BackButton/index.js
+++ b/app/components/BackButton/index.js
@@ -1,11 +1,23 @@
 // @flow
 import * as React from 'react';
 import { withRouter } from 'react-router';
+import styles from './style.scss';
 
-const BackButton = props => (
-  <div>
-    <button onClick={() => props.history.goBack()}>Back</button>
-  </div>
-);
+const BackButton = props => {
+  let backButton = null;
+
+  // Show back button only if there is app history (length > 2)
+  if (props.history.length > 2) {
+    backButton = (
+      <div>
+        <button onClick={() => props.history.goBack()} className={styles.backButton}>
+          &lt; Go back to Budget
+        </button>
+      </div>
+    );
+  }
+
+  return backButton;
+};
 
 export default withRouter(BackButton);

--- a/app/components/BackButton/index.js
+++ b/app/components/BackButton/index.js
@@ -1,0 +1,11 @@
+// @flow
+import * as React from 'react';
+import { withRouter } from 'react-router';
+
+const BackButton = props => (
+  <div>
+    <button onClick={() => props.history.goBack()}>Back</button>
+  </div>
+);
+
+export default withRouter(BackButton);

--- a/app/components/BackButton/style.scss
+++ b/app/components/BackButton/style.scss
@@ -1,0 +1,8 @@
+@import 'theme/variables';
+
+.backButton {
+  color: $btnBlue;
+  background: none;
+  border: none;
+  font-size: 1em;
+}

--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -23,7 +23,13 @@ exports[`renders correctly 1`] = `
     <div
       className="cellContent"
     >
-      Trader Joe's food
+      <a
+        className="undefined "
+        href="/transaction/1"
+        onClick={[Function]}
+      >
+        Trader Joe's food
+      </a>
     </div>
   </td>
   <td

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import BudgetGridRow from 'components/BudgetGridRow';
+import { MemoryRouter as Router } from 'react-router-dom'
 
 it('renders correctly', () => {
   const mockTransaction = {
@@ -15,6 +16,10 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const tree = renderer.create(
+    <Router>
+      <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
+    </Router>
+  ).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,8 +1,10 @@
 // @flow
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
+import NavLink from 'components/NavLink';
 import styles from './style.scss';
 
 type BudgetGridRowProps = {
@@ -24,7 +26,9 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
       </td>
       <td>
         <div className={styles.cellLabel}>Description</div>
-        <div className={styles.cellContent}>{description}</div>
+        <div className={styles.cellContent}>
+          <NavLink to={`/transaction/${id}`} label={description} styles={{}} />
+        </div>
       </td>
       <td className={amountCls}>
         <div className={styles.cellLabel}>Amount</div>

--- a/app/components/TransactionDetailPanel/index.js
+++ b/app/components/TransactionDetailPanel/index.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import transactionReducer from 'modules/transactions';
 import categoryReducer from 'modules/categories';
 import { injectAsyncReducers } from 'store';
+import BackButton from 'components/BackButton';
 
 // inject reducers that might not have been originally there
 injectAsyncReducers({
@@ -13,6 +14,7 @@ injectAsyncReducers({
 const TransactionDetailPanel = () => (
   <section>
     <div>Transaction detail page</div>
+    <BackButton />
   </section>
 );
 

--- a/app/components/TransactionDetailPanel/index.js
+++ b/app/components/TransactionDetailPanel/index.js
@@ -4,6 +4,7 @@ import transactionReducer from 'modules/transactions';
 import categoryReducer from 'modules/categories';
 import { injectAsyncReducers } from 'store';
 import BackButton from 'components/BackButton';
+import TransactionDetailContainer from 'containers/TransactionDetail';
 
 // inject reducers that might not have been originally there
 injectAsyncReducers({
@@ -13,8 +14,8 @@ injectAsyncReducers({
 
 const TransactionDetailPanel = () => (
   <section>
-    <div>Transaction detail page</div>
     <BackButton />
+    <TransactionDetailContainer />
   </section>
 );
 

--- a/app/components/TransactionDetailPanel/index.js
+++ b/app/components/TransactionDetailPanel/index.js
@@ -1,0 +1,19 @@
+// @flow
+import * as React from 'react';
+import transactionReducer from 'modules/transactions';
+import categoryReducer from 'modules/categories';
+import { injectAsyncReducers } from 'store';
+
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+  transactions: transactionReducer,
+  categories: categoryReducer,
+});
+
+const TransactionDetailPanel = () => (
+  <section>
+    <div>Transaction detail page</div>
+  </section>
+);
+
+export default TransactionDetailPanel;

--- a/app/components/TransactionOverview/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/TransactionOverview/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="transactionSection"
+>
+  <div
+    className="transactionTitle"
+  >
+    Paycheck
+  </div>
+  <div
+    className="transactionAmount pos"
+  >
+    +
+    45
+    % ($
+    5000
+    )
+  </div>
+</div>
+`;

--- a/app/components/TransactionOverview/__tests__/index-test.js
+++ b/app/components/TransactionOverview/__tests__/index-test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import TransactionOverview from '../';
+
+it('renders correctly', () => {
+  const transactionDesc = 'Paycheck';
+  const transactionValue = 5000;
+  const contributionPercent = 45;
+
+  const tree = renderer.create(
+    <TransactionOverview
+      transactionDesc={transactionDesc}
+      transactionValue={transactionValue}
+      contributionPercent={contributionPercent}
+    />
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/TransactionOverview/index.js
+++ b/app/components/TransactionOverview/index.js
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react';
+import styles from './style.scss';
+
+type TransactionOverviewProps = {
+  transactionDesc: string,
+  transactionValue: number,
+  contributionPercent: number,
+};
+
+const TransactionOverview = ({ transactionDesc, transactionValue, contributionPercent }: TransactionOverviewProps) => {
+  const isNegative = transactionValue < 0;
+  const amountCls = isNegative ? styles.neg : styles.pos || '';
+
+  return (
+    <div className={styles.transactionSection}>
+      <div className={styles.transactionTitle}>{transactionDesc}</div>
+      <div className={`${styles.transactionAmount} ${amountCls}`}>
+        {isNegative ? `-` : `+`}
+        {contributionPercent}% (${Math.abs(transactionValue)})
+      </div>
+    </div>
+  );
+};
+
+export default TransactionOverview;

--- a/app/components/TransactionOverview/style.scss
+++ b/app/components/TransactionOverview/style.scss
@@ -1,0 +1,25 @@
+@import 'theme/variables';
+
+.transactionSection {
+  margin-bottom: 5em;
+}
+
+.transactionTitle {
+  text-align: center;
+  font-size: 1.5em;
+  padding: 0.5em 0;
+}
+
+.transactionAmount {
+  text-align: center;
+  font-size: 1.2em;
+  padding-top: 0.5em;
+  margin-bottom: 2em;
+
+  &.neg {
+    color: $red;
+  }
+  &.pos {
+    color: $green;
+  }
+}

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -7,6 +7,7 @@ import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
+import TransactionDetail from 'routes/TransactionDetail';
 import './style.scss';
 
 const App = () => (
@@ -17,6 +18,7 @@ const App = () => (
       <Switch>
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
+        <Route path="/transaction/:id" component={TransactionDetail} />
         <Redirect to="/budget" />
       </Switch>
     </main>

--- a/app/containers/TransactionDetail/index.js
+++ b/app/containers/TransactionDetail/index.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom'
 import { getTransactions, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+import TransactionOverview from 'components/TransactionOverview';
 import DonutChart from 'components/DonutChart';
 import styles from './style.scss';
 
@@ -22,7 +23,7 @@ class TransactionDetailContainer extends React.Component<TransactionDetailProps>
     if (transactionData.length === 0) {
       return (
         <section>
-          <div>Transaction #{this.props.match.params.id} does not exist</div>
+          <div className={styles.transactionError}>Transaction #{this.props.match.params.id} does not exist</div>
         </section>
       );
     }
@@ -66,15 +67,13 @@ class TransactionDetailContainer extends React.Component<TransactionDetailProps>
       });
     }
 
-    const amountCls = isNegative ? styles.neg : styles.pos || '';
-
     return (
       <section>
-        <div className={styles.transactionTitle}>{transactionDesc}</div>
-        <div className={`${styles.transactionAmount} ${amountCls}`}>
-          {isNegative ? `-` : `+`}
-          {contributionPercent}% (${Math.abs(transactionValue)})
-        </div>
+        <TransactionOverview
+          transactionDesc={transactionDesc}
+          transactionValue={transactionValue}
+          contributionPercent={contributionPercent}
+        />
         <DonutChart data={chartData} dataLabel="description" dataKey="transactionId" />
       </section>
     );

--- a/app/containers/TransactionDetail/index.js
+++ b/app/containers/TransactionDetail/index.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom'
 import { getTransactions, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+import DonutChart from 'components/DonutChart';
 
 type TransactionDetailProps = {
   transactions: Transaction[],
@@ -32,6 +33,30 @@ class TransactionDetailContainer extends React.Component<TransactionDetailProps>
       ? (100 * Math.abs(transactionValue / outflow)).toFixed(2)
       : (100 * Math.abs(transactionValue / inflow)).toFixed(2);
 
+    const chartData = [
+      {
+        transactionId: transactionData[0].id,
+        value: Math.abs(transactionData[0].value),
+        description: transactionData[0].description,
+      },
+    ];
+
+    if (transactionData[0].value > 0) {
+      chartData.push({
+        transactionId: `${transactionData[0].id}+'other'`,
+        value: inflow - transactionData[0].value,
+        description: 'Other Income',
+      });
+    }
+
+    if (transactionData[0].value < 0) {
+      chartData.push({
+        transactionId: `${transactionData[0].id}+'other'`,
+        value: Math.abs(outflow - transactionData[0].value),
+        description: 'Other Expenses',
+      });
+    }
+
     return (
       <section>
         <h3>{transactionDesc}</h3>
@@ -44,12 +69,13 @@ class TransactionDetailContainer extends React.Component<TransactionDetailProps>
         <div>
           Value:
           {isNegative ? `-` : `+`}
+          $
           {Math.abs(transactionValue)}
         </div>
         <div>Total inflow: {inflow}</div>
         <div>Total outflow: {outflow}</div>
         <div>------</div>
-        <div>Chart -- To be placed here</div>
+        <DonutChart data={chartData} dataLabel="description" dataKey="transactionId" />
       </section>
     );
   }

--- a/app/containers/TransactionDetail/index.js
+++ b/app/containers/TransactionDetail/index.js
@@ -1,0 +1,64 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom'
+import { getTransactions, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+
+type TransactionDetailProps = {
+  transactions: Transaction[],
+  inflow: number,
+  outflow: number,
+};
+
+class TransactionDetailContainer extends React.Component<TransactionDetailProps> {
+  render() {
+    const { transactions, inflow, outflow } = this.props;
+    const transactionId = Number(this.props.match.params.id);
+    const transactionData = transactions.filter(transaction => transaction.id === transactionId);
+
+    // Invalid transaction ID
+    if(transactionData.length === 0) {
+      return (
+        <section>
+          <div>Transaction #{this.props.match.params.id} does not exist</div>
+        </section>
+      );
+    }
+
+    const transactionDesc = transactionData[0].description;
+    const transactionValue = transactionData[0].value;
+    const isNegative = transactionValue < 0;
+    const contributionPercent = isNegative
+      ? (100 * Math.abs(transactionValue / outflow)).toFixed(2)
+      : (100 * Math.abs(transactionValue / inflow)).toFixed(2);
+
+    return (
+      <section>
+        <h3>{transactionDesc}</h3>
+        <div>
+          Percent:
+          {isNegative ? `-` : `+`}
+          {contributionPercent}
+          %
+        </div>
+        <div>
+          Value:
+          {isNegative ? `-` : `+`}
+          {Math.abs(transactionValue)}
+        </div>
+        <div>Total inflow: {inflow}</div>
+        <div>Total outflow: {outflow}</div>
+        <div>------</div>
+        <div>Chart -- To be placed here</div>
+      </section>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  transactions: getTransactions(state),
+  inflow: getInflowBalance(state),
+  outflow: getOutflowBalance(state),
+});
+
+export default withRouter(connect(mapStateToProps)(TransactionDetailContainer));

--- a/app/containers/TransactionDetail/index.js
+++ b/app/containers/TransactionDetail/index.js
@@ -19,7 +19,7 @@ class TransactionDetailContainer extends React.Component<TransactionDetailProps>
     const transactionData = transactions.filter(transaction => transaction.id === transactionId);
 
     // Invalid transaction ID
-    if(transactionData.length === 0) {
+    if (transactionData.length === 0) {
       return (
         <section>
           <div>Transaction #{this.props.match.params.id} does not exist</div>
@@ -30,30 +30,38 @@ class TransactionDetailContainer extends React.Component<TransactionDetailProps>
     const transactionDesc = transactionData[0].description;
     const transactionValue = transactionData[0].value;
     const isNegative = transactionValue < 0;
+
+    // For inflow transactions, the contribution is calculated with respect to total inflow
+    // For outflow transactions, the contribution is calculated with respect to total outflow
     const contributionPercent = isNegative
       ? (100 * Math.abs(transactionValue / outflow)).toFixed(2)
       : (100 * Math.abs(transactionValue / inflow)).toFixed(2);
 
+    // Add current transation item as first item in the chart data
     const chartData = [
       {
-        transactionId: transactionData[0].id,
-        value: Math.abs(transactionData[0].value),
-        description: transactionData[0].description,
+        transactionId: `${transactionId}+''`,
+        value: Math.abs(transactionValue),
+        description: transactionDesc,
       },
     ];
 
-    if (transactionData[0].value > 0) {
+    // For inflow transaction, push the remaining inflow (ie. total inflow minus current transaction value)
+    // as second chart item for comparison
+    if (transactionValue > 0) {
       chartData.push({
-        transactionId: `${transactionData[0].id}+'other'`,
-        value: inflow - transactionData[0].value,
+        transactionId: `${transactionId}+'other'`,
+        value: inflow - transactionValue,
         description: 'Other Income',
       });
     }
 
-    if (transactionData[0].value < 0) {
+    // For outflow transaction, push the remaining outflow (ie. total outflow minus current transaction value)
+    // as second chart item for comparison
+    if (transactionValue < 0) {
       chartData.push({
-        transactionId: `${transactionData[0].id}+'other'`,
-        value: Math.abs(outflow - transactionData[0].value),
+        transactionId: `${transactionId}+'other'`,
+        value: Math.abs(outflow - transactionValue),
         description: 'Other Expenses',
       });
     }

--- a/app/containers/TransactionDetail/index.js
+++ b/app/containers/TransactionDetail/index.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom'
 import { getTransactions, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
 import DonutChart from 'components/DonutChart';
+import styles from './style.scss';
 
 type TransactionDetailProps = {
   transactions: Transaction[],
@@ -57,24 +58,15 @@ class TransactionDetailContainer extends React.Component<TransactionDetailProps>
       });
     }
 
+    const amountCls = isNegative ? styles.neg : styles.pos || '';
+
     return (
       <section>
-        <h3>{transactionDesc}</h3>
-        <div>
-          Percent:
+        <div className={styles.transactionTitle}>{transactionDesc}</div>
+        <div className={`${styles.transactionAmount} ${amountCls}`}>
           {isNegative ? `-` : `+`}
-          {contributionPercent}
-          %
+          {contributionPercent}% (${Math.abs(transactionValue)})
         </div>
-        <div>
-          Value:
-          {isNegative ? `-` : `+`}
-          $
-          {Math.abs(transactionValue)}
-        </div>
-        <div>Total inflow: {inflow}</div>
-        <div>Total outflow: {outflow}</div>
-        <div>------</div>
         <DonutChart data={chartData} dataLabel="description" dataKey="transactionId" />
       </section>
     );

--- a/app/containers/TransactionDetail/style.scss
+++ b/app/containers/TransactionDetail/style.scss
@@ -1,0 +1,21 @@
+@import 'theme/variables';
+
+.transactionTitle {
+  text-align: center;
+  font-size: 1.5em;
+  padding: 0.5em 0;
+}
+
+.transactionAmount {
+  text-align: center;
+  font-size: 1.2em;
+  padding-top: 0.5em;
+  margin-bottom: 2em;
+
+  &.neg {
+    color: $red;
+  }
+  &.pos {
+    color: $green;
+  }
+}

--- a/app/containers/TransactionDetail/style.scss
+++ b/app/containers/TransactionDetail/style.scss
@@ -1,21 +1,8 @@
 @import 'theme/variables';
 
-.transactionTitle {
-  text-align: center;
-  font-size: 1.5em;
-  padding: 0.5em 0;
-}
-
-.transactionAmount {
-  text-align: center;
+.transactionError {
+  text-align: left;
   font-size: 1.2em;
-  padding-top: 0.5em;
-  margin-bottom: 2em;
-
-  &.neg {
-    color: $red;
-  }
-  &.pos {
-    color: $green;
-  }
+  padding: 0.5em 0;
+  color: $red;
 }

--- a/app/routes/TransactionDetail/index.js
+++ b/app/routes/TransactionDetail/index.js
@@ -1,0 +1,13 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadTransactionDetailPanel = () => import('components/TransactionDetailPanel');
+
+class TransactionDetail extends Component<{}> {
+  render() {
+    return <Chunk load={loadTransactionDetailPanel} />;
+  }
+}
+
+export default TransactionDetail;

--- a/app/theme/_variables.scss
+++ b/app/theme/_variables.scss
@@ -10,6 +10,7 @@ $verylightgray: #f0f0f0;
 $darkgray: rgba(0,0,0,0.16);
 $red: #eb2a2a;
 $green: #189c2d;
+$btnBlue: #0051ff;
 
 // media
 $screen-small: 767px;


### PR DESCRIPTION
## Feature

View the percentage contribution of a transaction with respect to the total budget (income or expense).

## Proposed Changes

* Create a transaction detail view page.
* Create a link to the transaction detail page from the budget list page.
* Have a back navigation button to return to previous router.
* Transaction detail page should display the description / title, percentage contribution with a + [plus] sign for inflow and - [minus] sign for outflow and a pie/donut chart showing the percentage contribution in overall budget.

## Screenshot

![screen shot 2018-03-15 at 4 06 34 pm](https://user-images.githubusercontent.com/2136271/37461171-883caef2-2873-11e8-8ab0-848e3fd6e54e.png)
![screen shot 2018-03-15 at 4 06 43 pm](https://user-images.githubusercontent.com/2136271/37461173-889ce2a4-2873-11e8-9ec5-1411961bdff2.png)
![screen shot 2018-03-15 at 4 07 01 pm](https://user-images.githubusercontent.com/2136271/37461176-88f6cbca-2873-11e8-81a8-8b5038c33eda.png)
![screen shot 2018-03-15 at 4 07 23 pm](https://user-images.githubusercontent.com/2136271/37461178-8943bbba-2873-11e8-93c7-5c429aad35a4.png)
![screen shot 2018-03-15 at 4 07 51 pm](https://user-images.githubusercontent.com/2136271/37461181-89995c64-2873-11e8-9382-ed2640b614dd.png)
![screen shot 2018-03-15 at 4 08 00 pm](https://user-images.githubusercontent.com/2136271/37461185-89eeab06-2873-11e8-8c68-168b6bc51a2f.png)
![screen shot 2018-03-15 at 4 08 11 pm](https://user-images.githubusercontent.com/2136271/37461187-8a4fb16c-2873-11e8-8ea3-116c2862392f.png)
![screen shot 2018-03-15 at 4 08 21 pm](https://user-images.githubusercontent.com/2136271/37461188-8aad52e0-2873-11e8-90c7-9de3c043b94f.png)

## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in some parts of code
* [x] Tested for desktop and mobile compatibility