### PR TITLE
Feature - Transaction detail

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -40,5 +40,13 @@ exports[`renders correctly 1`] = `
       -$423.34
     </div>
   </td>
+  <td>
+    <a
+      href="/item/1"
+      onClick={[Function]}
+    >
+      Details
+    </a>
+  </td>
 </tr>
 `;

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
 import BudgetGridRow from 'components/BudgetGridRow';
 
 it('renders correctly', () => {
@@ -15,6 +16,12 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const tree = renderer
+    .create(
+      <MemoryRouter>
+        <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
+      </MemoryRouter>
+    )
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
@@ -29,6 +30,9 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
       <td className={amountCls}>
         <div className={styles.cellLabel}>Amount</div>
         <div className={styles.cellContent}>{amount.text}</div>
+      </td>
+      <td>
+        <Link to={`/item/${id}`}>Details</Link>
       </td>
     </tr>
   );

--- a/app/components/GoBack/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/GoBack/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="containerGoBack"
+  onClick={[Function]}
+  role="button"
+  tabIndex="0"
+>
+  <span>
+    ← Back
+  </span>
+</div>
+`;

--- a/app/components/GoBack/__tests__/index-test.js
+++ b/app/components/GoBack/__tests__/index-test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import GoBack from '../';
+
+it('renders correctly', () => {
+  const tree = renderer.create(<GoBack text="← Back" goBack={() => {}} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/GoBack/index.js
+++ b/app/components/GoBack/index.js
@@ -7,7 +7,7 @@ type GoBackProps = {
   text: string,
 };
 
-const GoBack = (props : GoBackProps) => (
+const GoBack = (props: GoBackProps) => (
   <div className={styles.containerGoBack} onClick={props.goBack} role="button" tabIndex="0">
     <span>{props.text}</span>
   </div>

--- a/app/components/GoBack/index.js
+++ b/app/components/GoBack/index.js
@@ -1,0 +1,16 @@
+// @flow
+import React from 'react';
+import styles from './styles.scss';
+
+type GoBackProps = {
+  goBack: Function,
+  text: string,
+};
+
+const GoBack = (props): GoBackProps => (
+  <div className={styles.containerGoBack} onClick={props.goBack} role="button" tabIndex="0">
+    <span>{props.text}</span>
+  </div>
+);
+
+export default GoBack;

--- a/app/components/GoBack/index.js
+++ b/app/components/GoBack/index.js
@@ -7,7 +7,7 @@ type GoBackProps = {
   text: string,
 };
 
-const GoBack = (props): GoBackProps => (
+const GoBack = (props : GoBackProps) => (
   <div className={styles.containerGoBack} onClick={props.goBack} role="button" tabIndex="0">
     <span>{props.text}</span>
   </div>

--- a/app/components/GoBack/styles.scss
+++ b/app/components/GoBack/styles.scss
@@ -1,0 +1,7 @@
+.containerGoBack {
+  cursor: pointer;
+  display: inline;
+  border: 1px solid black;
+  width: 70px;
+  margin: 5px;
+}

--- a/app/components/ItemDetailsTitle/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/ItemDetailsTitle/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="negative"
+>
+  <h3>
+    I am a transaction.
+  </h3>
+  <p>
+    is the 22% of the outflows
+  </p>
+</div>
+`;

--- a/app/components/ItemDetailsTitle/__tests__/index-test.js
+++ b/app/components/ItemDetailsTitle/__tests__/index-test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import ItemDetailsTitle from '../';
+
+const ItemDetailsTitleProps = {
+  description: 'I am a transaction.',
+  subtitle: 'is the 22% of the outflows',
+  isNegative: true,
+};
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create(
+      <ItemDetailsTitle
+        title={ItemDetailsTitleProps.description}
+        subtitle={ItemDetailsTitleProps.subtitle}
+        type={ItemDetailsTitleProps.isNegative}
+      />
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/ItemDetailsTitle/index.js
+++ b/app/components/ItemDetailsTitle/index.js
@@ -1,0 +1,18 @@
+// @flow
+import React from 'react';
+import styles from './styles.scss';
+
+type ItemDetailtsTitleProps = {
+  title: string,
+  subtitle: string,
+  type: Boolean,
+};
+
+const ItemDetailtsTitle = ({ title, subtitle, type }): ItemDetailtsTitleProps => (
+  <div className={type ? styles.negative : styles.positive}>
+    <h3>{title}</h3>
+    <p>{subtitle}</p>
+  </div>
+);
+
+export default ItemDetailtsTitle;

--- a/app/components/ItemDetailsTitle/styles.scss
+++ b/app/components/ItemDetailsTitle/styles.scss
@@ -1,0 +1,21 @@
+  h3, p {
+    text-align: center
+  }
+
+  .negative {
+    h3 {
+      font-weight: bold;
+    }
+    p {
+      color: red;
+    }
+  }
+
+  .positive {
+    h3 {
+      font-weight: bold;
+    }
+    p {
+      color: blue;
+    }
+  }

--- a/app/components/Legend/LegendItem.js
+++ b/app/components/Legend/LegendItem.js
@@ -7,12 +7,13 @@ type LegendItemProps = {
   color: string,
   value: number,
   label: string,
+  percentage: Boolean,
 };
 
-const LegendItem = ({ color, label, value }: LegendItemProps) => (
+const LegendItem = ({ color, label, value, percentage }: LegendItemProps) => (
   <li style={{ color }}>
     <span>{label}</span>
-    <span className={styles.value}> {formatAmount(value).text} </span>
+    <span className={styles.value}> {formatAmount(value, true, percentage).text} </span>
   </li>
 );
 

--- a/app/components/Legend/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/Legend/__tests__/__snapshots__/index-test.js.snap
@@ -7,11 +7,13 @@ exports[`renders correctly 1`] = `
   <div
     color={undefined}
     label={undefined}
+    percentage={undefined}
     value={undefined}
   />
   <div
     color={undefined}
     label={undefined}
+    percentage={undefined}
     value={undefined}
   />
 </ul>

--- a/app/components/Legend/index.js
+++ b/app/components/Legend/index.js
@@ -17,7 +17,13 @@ type LegendType = {
 const Legend = ({ data, color, dataValue, dataLabel, dataKey, reverse }: LegendType) => (
   <ul className={cx(styles.legend, { [styles.reverse]: reverse })}>
     {data.map((item, idx) => (
-      <LegendItem color={color(idx)} key={item[dataKey]} label={item[dataLabel]} value={item[dataValue]} />
+      <LegendItem
+        color={color(idx)}
+        key={item[dataKey]}
+        label={item[dataLabel]}
+        value={item[dataValue]}
+        percentage={item.percentage}
+      />
     ))}
   </ul>
 );

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -7,15 +7,16 @@ import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
+import ItemDetails from 'routes/ItemDetails';
 import './style.scss';
 
 const App = () => (
   <ErrorBoundary fallbackComponent={AppError}>
     <main>
       <Header />
-
       <Switch>
         <Route path="/budget" component={Budget} />
+        <Route path="/item/:id" component={ItemDetails} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />
       </Switch>

--- a/app/containers/BudgetGrid/__tests__/__snapshots__/index-test.js.snap
+++ b/app/containers/BudgetGrid/__tests__/__snapshots__/index-test.js.snap
@@ -15,6 +15,9 @@ exports[`renders correctly 1`] = `
       <th>
         Amount
       </th>
+      <th>
+        More
+      </th>
     </tr>
   </thead>
   <tbody />

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -29,6 +29,7 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
             <th>Category</th>
             <th>Description</th>
             <th>Amount</th>
+            <th>More</th>
           </tr>
         </thead>
         <tbody>

--- a/app/containers/ItemDetails/index.js
+++ b/app/containers/ItemDetails/index.js
@@ -1,0 +1,78 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import GoBack from 'components/GoBack';
+import DonutChart from 'components/DonutChart';
+import ItemDetailsTitle from 'components/ItemDetailsTitle';
+import transactionReducer from 'modules/transactions';
+import { getTransactions, getTransactionById, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+import { injectAsyncReducers } from 'store';
+import styles from './style.scss';
+
+injectAsyncReducers({
+  transactions: transactionReducer,
+});
+
+type ItemDetailsProps = {
+  transactions: [],
+  inflows: Number,
+  outflows: Number,
+  inflowTransactions: [],
+  outflowTransactions: [],
+};
+
+class ItemDetails extends React.Component<ItemDetailsProps> {
+  getPercentage = (value, total): Number => Number((value * 100 / total).toFixed(2));
+  isNegative = (transaction): Boolean => Math.sign(transaction.value) === -1;
+  fillDonusData = (transaction, percentage, isNegative): Array => [
+    {
+      description: transaction.description,
+      key: 1,
+      value: percentage,
+      percentage: true,
+    },
+    {
+      description: isNegative ? 'Other Outflows' : 'Other Inflows',
+      key: 2,
+      value: 100 - percentage,
+      percentage: true,
+    },
+  ];
+
+  render() {
+    const { transactions, inflows, outflows, history } = this.props;
+
+    const id = Number(this.props.match.params.id);
+    const transaction = getTransactionById(transactions, id);
+    if (transaction) {
+      const isNegative = this.isNegative(transaction);
+
+      const percentage = isNegative
+        ? this.getPercentage(transaction.value, outflows)
+        : this.getPercentage(transaction.value, inflows);
+
+      const color = isNegative ? ['rgb(43, 153, 64)', 'rgb(125, 200, 115)'] : ['rgb(201, 39, 54)', 'rgb(236, 86, 82)'];
+
+      const donusData = this.fillDonusData(transaction, percentage, isNegative);
+      const description = `It's ${percentage} % of the ${isNegative ? 'Outflows' : 'Inflows'}`;
+
+      return (
+        <section className={styles.boxItemDetail}>
+          <GoBack text="← Back" goBack={history.goBack} />
+          <ItemDetailsTitle title={transaction.description} subtitle={description} type={isNegative} />
+          <DonutChart data={donusData} dataLabel="description" dataKey="key" />
+        </section>
+      );
+    }
+
+    return <div> There is no transaction with the following id: {id}</div>;
+  }
+}
+
+const mapStateToProps = state => ({
+  transactions: getTransactions(state),
+  inflows: getInflowBalance(state),
+  outflows: getOutflowBalance(state),
+});
+
+export default connect(mapStateToProps)(ItemDetails);

--- a/app/containers/ItemDetails/index.js
+++ b/app/containers/ItemDetails/index.js
@@ -51,8 +51,6 @@ class ItemDetails extends React.Component<ItemDetailsProps> {
         ? this.getPercentage(transaction.value, outflows)
         : this.getPercentage(transaction.value, inflows);
 
-      const color = isNegative ? ['rgb(43, 153, 64)', 'rgb(125, 200, 115)'] : ['rgb(201, 39, 54)', 'rgb(236, 86, 82)'];
-
       const donusData = this.fillDonusData(transaction, percentage, isNegative);
       const description = `It's ${percentage} % of the ${isNegative ? 'Outflows' : 'Inflows'}`;
 

--- a/app/containers/ItemDetails/style.scss
+++ b/app/containers/ItemDetails/style.scss
@@ -1,0 +1,5 @@
+.boxItemDetail {
+  border: 1px solid #b1b1b1;
+  height: 100%;
+  margin: 10px;
+}

--- a/app/routes/ItemDetails/index.js
+++ b/app/routes/ItemDetails/index.js
@@ -1,0 +1,10 @@
+// @flow
+import React from 'react';
+
+import Chunk from 'components/Chunk';
+
+const loadItemDetailsContainer = () => import('containers/ItemDetails');
+
+const ItemDetails = props => <Chunk load={loadItemDetailsContainer} {...props} />;
+
+export default ItemDetails;

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -39,11 +39,14 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
 
-const getInflowTransactions = createSelector([getTransactions], transactions =>
+export const getTransactionById = (transactions: Transaction[], id: Number): Transaction =>
+  transactions.find(transaction => transaction.id === id);
+
+export const getInflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value > 0)
 );
 
-const getOutflowTransactions = createSelector([getTransactions], transactions =>
+export const getOutflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value < 0)
 );
 

--- a/app/utils/formatAmount.js
+++ b/app/utils/formatAmount.js
@@ -5,12 +5,18 @@ export type FormattedAmount = {
   isNegative: boolean,
 };
 
-export default function formatAmount(amount: number, showSign: boolean = true): FormattedAmount {
+export default function formatAmount(
+  amount: number,
+  showSign: boolean = true,
+  percentage: boolean = false
+): FormattedAmount {
+  let formatValue = '';
   const isNegative = amount < 0;
-  const formatValue = Math.abs(amount).toLocaleString('en-us', {
-    style: 'currency',
-    currency: 'USD',
-  });
+  if (percentage) {
+    formatValue = `${amount} %`;
+  } else {
+    formatValue = Math.abs(amount).toLocaleString('en-us', { style: 'currency', currency: 'USD' });
+  }
 
   return {
     text: `${isNegative && showSign ? '-' : ''}${formatValue}`,


### PR DESCRIPTION
## Proposed Changes

Added new feature where you can see the  percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items.

## Screenshot

/budget
<img width="1359" alt="screen shot 2018-03-26 at 13 08 59" src="https://user-images.githubusercontent.com/15804684/37918544-bc20479c-30f7-11e8-81a6-9a6f7b4805df.png">

/item/1
<img width="1378" alt="screen shot 2018-03-26 at 13 16 53" src="https://user-images.githubusercontent.com/15804684/37918619-fef2edcc-30f7-11e8-952b-55c5d306582a.png">


## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [ ] Comments in code
* [ ] Documentation written
