### PR TITLE
add transaction details page

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import BudgetGridRow from 'components/BudgetGridRow';
+import { MemoryRouter as Router } from 'react-router-dom';
 
 it('renders correctly', () => {
   const mockTransaction = {
@@ -15,6 +16,12 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const tree = renderer
+    .create(
+      <Router>
+        <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
+      </Router>
+    )
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { withRouter } from 'react-router-dom';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
@@ -8,16 +9,25 @@ import styles from './style.scss';
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  history: Object,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, history }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
+  /**
+  * @name goToTransaction
+  * @desc rogrammatically change route so that whole <tr> is clickable
+  */
+  const goToTransaction = () => {
+    history.push(`/transaction/${id}`);
+  };
+
   return (
-    <tr key={id}>
+    <tr key={id} onClick={goToTransaction}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>
@@ -34,4 +44,4 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
   );
 };
 
-export default BudgetGridRow;
+export default withRouter(BudgetGridRow);

--- a/app/components/TransactionDetails/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/TransactionDetails/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="transaction__details"
+>
+  <h2>
+    Trader Joe's food
+  </h2>
+  <h4
+    className="neg"
+  >
+    30
+    % ($
+    -423.34
+    )
+  </h4>
+</div>
+`;

--- a/app/components/TransactionDetails/__tests__/index-test.js
+++ b/app/components/TransactionDetails/__tests__/index-test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import render from 'react-test-renderer';
+import TransactionDetails from '../';
+
+it('renders correctly', () => {
+  const mockTransaction = {
+    id: 1,
+    description: "Trader Joe's food",
+    value: -423.34,
+    categoryId: 1,
+  };
+  const mockPercentage = '30';
+
+  const tree = render.create(<TransactionDetails transaction={mockTransaction} percentage={mockPercentage} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/TransactionDetails/index.js
+++ b/app/components/TransactionDetails/index.js
@@ -1,0 +1,20 @@
+// @flow
+import * as React from 'react';
+import type { Transaction } from 'modules/transactions';
+import styles from './style.scss';
+
+type TransactionDetailsProps = {
+  transaction: Transaction,
+  percentage: string,
+};
+
+const TransactionDetails = ({ transaction, percentage }: TransactionDetailsProps) => (
+  <div className="transaction__details">
+    <h2>{transaction.description}</h2>
+    <h4 className={transaction.value > 0 ? styles.pos : styles.neg}>
+      {percentage}% (${transaction.value})
+    </h4>
+  </div>
+);
+
+export default TransactionDetails;

--- a/app/components/TransactionDetails/style.scss
+++ b/app/components/TransactionDetails/style.scss
@@ -1,0 +1,13 @@
+@import 'theme/variables';
+
+.transaction__details {
+  text-align: left;
+}
+
+.neg {
+  color: $red;
+}
+
+.pos {
+  color: $green;
+}

--- a/app/components/TransactionNav/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/TransactionNav/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="transaction__nav"
+>
+  <a
+    href="/budget"
+    onClick={[Function]}
+  >
+    Go back
+  </a>
+</div>
+`;

--- a/app/components/TransactionNav/__tests__/index-test.js
+++ b/app/components/TransactionNav/__tests__/index-test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import render from 'react-test-renderer';
+import { MemoryRouter as Router } from 'react-router-dom';
+import TransactionNav from '../';
+
+it('renders correctly', () => {
+  const tree = render
+    .create(
+      <Router>
+        <TransactionNav />
+      </Router>
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/TransactionNav/index.js
+++ b/app/components/TransactionNav/index.js
@@ -1,0 +1,12 @@
+// @flow
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import styles from './style.scss';
+
+const TransactionNav = () => (
+  <div className={styles.transaction__nav}>
+    <Link to="/budget">Go back</Link>
+  </div>
+);
+
+export default TransactionNav;

--- a/app/components/TransactionNav/style.scss
+++ b/app/components/TransactionNav/style.scss
@@ -1,0 +1,21 @@
+@import 'theme/main';
+
+.transaction__nav {
+  border: 1px solid $lightgray;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: row;
+  max-height: 3em;
+  margin-bottom: 2em;
+
+  a {
+    float: left;
+    padding: 1em 2em;
+    white-space: nowrap;
+    font-size: 0.9em;
+    outline: none;
+    color: $black;
+    text-decoration: none;
+    background-color: $verylightgray;
+  }
+}

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -7,6 +7,7 @@ import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
 import Reports from 'routes/Reports';
+import Transaction from 'routes/Transaction';
 import './style.scss';
 
 const App = () => (
@@ -17,6 +18,7 @@ const App = () => (
       <Switch>
         <Route path="/budget" component={Budget} />
         <Route path="/reports" component={Reports} />
+        <Route path="/transaction/:id" component={Transaction} />
         <Redirect to="/budget" />
       </Switch>
     </main>

--- a/app/containers/BudgetGrid/style.scss
+++ b/app/containers/BudgetGrid/style.scss
@@ -49,6 +49,7 @@
 
     tr {
       border-bottom: 1px solid $lightgray;
+      cursor: pointer;
     }
 
     td {

--- a/app/containers/Transaction/__tests__/__snapshots__/index-test.js.snap
+++ b/app/containers/Transaction/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders error 1`] = `
+<section>
+  <div
+    className="transaction__nav"
+  >
+    <a
+      href="/budget"
+      onClick={[Function]}
+    >
+      Go back
+    </a>
+  </div>
+  Ooops, transaction not found!
+</section>
+`;

--- a/app/containers/Transaction/__tests__/index-test.js
+++ b/app/containers/Transaction/__tests__/index-test.js
@@ -1,0 +1,19 @@
+import store from 'store';
+import React from 'react';
+import { Provider } from 'react-redux';
+import render from 'react-test-renderer';
+import { MemoryRouter as Router } from 'react-router-dom';
+import Transaction from '../';
+
+it('renders error', () => {
+  const tree = render
+    .create(
+      <Provider store={store}>
+        <Router>
+          <Transaction />
+        </Router>
+      </Provider>
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/containers/Transaction/index.js
+++ b/app/containers/Transaction/index.js
@@ -1,0 +1,70 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import transactionReducer from 'modules/transactions';
+import { getTransactions, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+import { injectAsyncReducers } from 'store';
+import TransactionDetails from 'components/TransactionDetails';
+import TransactionNav from 'components/TransactionNav';
+import DonutChart from 'components/DonutChart';
+
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+  transactions: transactionReducer,
+});
+
+type TransactionProps = {
+  transactions: Transaction[],
+  match: Object,
+  inflow: Number,
+  outflow: Number,
+};
+
+const TransactionContainer = ({ transactions, match, inflow, outflow }: TransactionProps) => {
+  // find transaction by the id passed in the url
+  const transaction = transactions.find(t => t.id === Number(match.params.id));
+  if (!transaction) {
+    return (
+      <section>
+        <TransactionNav />
+        Ooops, transaction not found!
+      </section>
+    );
+  }
+
+  const isNegative = transaction.value < 0;
+  // depending on transaction.value, calculate percentage accordingly
+  const percentage = isNegative
+    ? (100 * Math.abs(transaction.value / outflow)).toFixed(2)
+    : (100 * Math.abs(transaction.value / inflow)).toFixed(2);
+  // [selected transaction details, remainder outflow/inflow details]
+  const chart = [
+    {
+      transactionId: `${transaction.id}+''`,
+      value: Math.abs(transaction.value),
+      description: `${transaction.description} - `,
+    },
+    {
+      transactionId: `${transaction.id}+'-remainder'`,
+      value: isNegative ? Math.abs(outflow - transaction.value) : inflow - transaction.value,
+      description: isNegative ? 'Outflow Remainder - ' : 'Inflow Remainder - ',
+    },
+  ];
+
+  return (
+    <section>
+      <TransactionNav />
+      <TransactionDetails transaction={transaction} percentage={percentage} />
+      <DonutChart data={chart} dataLabel="description" dataKey="transactionId" />
+    </section>
+  );
+};
+
+const mapStateToProps = state => ({
+  transactions: getTransactions(state),
+  inflow: getInflowBalance(state),
+  outflow: getOutflowBalance(state),
+});
+
+export default withRouter(connect(mapStateToProps)(TransactionContainer));

--- a/app/routes/Transaction/index.js
+++ b/app/routes/Transaction/index.js
@@ -1,0 +1,13 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadItemContainer = () => import('containers/Transaction' /* webpackChunkName: "transaction" */);
+
+class Transaction extends Component<{}> {
+  render() {
+    return <Chunk load={loadItemContainer} />;
+  }
+}
+
+export default Transaction;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webpack2-react-redux-budget-app-sample",
   "version": "2.0.0",
   "private": true,
-  "description": "Budgeting App Sample - React, Redux, Webpack 2",
+  "description": "Budgeting App Sample - React, Redux, Webpack 3",
   "license": "MIT",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Proposed Changes

* Acceptance Criteria
* Given that I have added at least one item to the budgeting grid* 
* When I click on that item
* Then I want to see a new page with a title corresponding to the item details
* And route should be dynamic with item ID in it
* And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow
* And a pie chart showing how much of the entire budget this item is contributing with should be on that page
* And no other items from the budget should be on that pie chart
* And there should be a back button to return back to the previous route
* And the view should be mobile and desktop compatible

No special styling is necessary.

## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [x] Documentation written



Who spends 2300$ on pancakes?? :joy: :joy: 