### PR TITLE
Feature: Budget item detail

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,44 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  className="row"
+>
   <td>
-    <div
-      className="cellLabel"
+    <a
+      className="navLink"
+      href="/budget/1"
+      onClick={[Function]}
     >
-      Category
-    </div>
-    <div
-      className="cellContent"
-    >
-      Groceries
-    </div>
+      <div
+        className="cellLabel"
+      >
+        Category
+      </div>
+      <div
+        className="cellContent"
+      >
+        Groceries
+      </div>
+    </a>
   </td>
   <td>
-    <div
-      className="cellLabel"
+    <a
+      className="navLink"
+      href="/budget/1"
+      onClick={[Function]}
     >
-      Description
-    </div>
-    <div
-      className="cellContent"
-    >
-      Trader Joe's food
-    </div>
+      <div
+        className="cellLabel"
+      >
+        Description
+      </div>
+      <div
+        className="cellContent"
+      >
+        Trader Joe's food
+      </div>
+    </a>
   </td>
   <td
     className="neg"
   >
-    <div
-      className="cellLabel"
+    <a
+      className="navLink"
+      href="/budget/1"
+      onClick={[Function]}
     >
-      Amount
-    </div>
-    <div
-      className="cellContent"
-    >
-      -$423.34
-    </div>
+      <div
+        className="cellLabel"
+      >
+        Amount
+      </div>
+      <div
+        className="cellContent"
+      >
+        -$423.34
+      </div>
+    </a>
   </td>
 </tr>
 `;

--- a/app/components/BudgetGridRow/__tests__/index-test.js
+++ b/app/components/BudgetGridRow/__tests__/index-test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { MemoryRouter } from 'react-router-dom';
 import BudgetGridRow from 'components/BudgetGridRow';
 
 it('renders correctly', () => {
@@ -15,6 +16,12 @@ it('renders correctly', () => {
     2: 'School',
   };
 
-  const tree = renderer.create(<BudgetGridRow transaction={mockTransaction} categories={mockCategories} />).toJSON();
+  const tree = renderer
+    .create(
+      <MemoryRouter initialEntries={['/budget']}>
+        <BudgetGridRow transaction={mockTransaction} categories={mockCategories} />
+      </MemoryRouter>
+    )
+    .toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import formatAmount from 'utils/formatAmount';
 import type { Transaction } from 'modules/transactions';
 import type { Categories } from 'modules/categories';
@@ -15,20 +16,27 @@ const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
+  const budgetDetailUrl = `/budget/${id}`;
 
   return (
-    <tr key={id}>
+    <tr key={id} className={styles.row}>
       <td>
-        <div className={styles.cellLabel}>Category</div>
-        <div className={styles.cellContent}>{category}</div>
+        <Link to={budgetDetailUrl} className={styles.navLink}>
+          <div className={styles.cellLabel}>Category</div>
+          <div className={styles.cellContent}>{category}</div>
+        </Link>
       </td>
       <td>
-        <div className={styles.cellLabel}>Description</div>
-        <div className={styles.cellContent}>{description}</div>
+        <Link to={budgetDetailUrl} className={styles.navLink}>
+          <div className={styles.cellLabel}>Description</div>
+          <div className={styles.cellContent}>{description}</div>
+        </Link>
       </td>
       <td className={amountCls}>
-        <div className={styles.cellLabel}>Amount</div>
-        <div className={styles.cellContent}>{amount.text}</div>
+        <Link to={budgetDetailUrl} className={styles.navLink}>
+          <div className={styles.cellLabel}>Amount</div>
+          <div className={styles.cellContent}>{amount.text}</div>
+        </Link>
       </td>
     </tr>
   );

--- a/app/components/BudgetGridRow/style.scss
+++ b/app/components/BudgetGridRow/style.scss
@@ -21,3 +21,14 @@
 .pos {
   color: $green;
 }
+
+.row:hover {
+  cursor: pointer;
+  background-color:$verylightgray;
+}
+
+.navLink {
+  color: inherit;
+  text-decoration: none;
+  width: 100%;
+}

--- a/app/components/BudgetItemDetail/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetItemDetail/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="budgetItemDetail"
+>
+  <h1>
+    Mock testing description
+  </h1>
+  <h2>
+    <span
+      className="income"
+    >
+      +
+    </span>
+    33.33
+    %
+  </h2>
+  <MockPieChart
+    data={
+      Array [
+        Object {
+          "category": "33.33% - Mock testing description",
+          "categoryId": "item",
+          "value": 33.33,
+        },
+        Object {
+          "category": "66.67% - Other incomes",
+          "categoryId": "total",
+          "value": 66.67,
+        },
+      ]
+    }
+    dataKey="categoryId"
+    dataLabel="category"
+  />
+</div>
+`;

--- a/app/components/BudgetItemDetail/__tests__/index-test.js
+++ b/app/components/BudgetItemDetail/__tests__/index-test.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+import BudgetItemDetail from 'components/BudgetItemDetail';
+import styles from '../style.scss';
+
+jest.mock('components/PieChart/Path');
+jest.mock('components/PieChart', () => 'MockPieChart');
+
+function setup(isOutflow = false) {
+  const transaction = {
+    id: 1,
+    categoryId: 1,
+    description: 'Mock testing description',
+    value: isOutflow ? -33.33 : 33.33,
+  };
+
+  const balance = isOutflow ? -100 : 100;
+
+  const props = {
+    transaction,
+    balance,
+  };
+  const enzymeWrapper = shallow(<BudgetItemDetail {...props} />);
+
+  return {
+    enzymeWrapper,
+    props,
+  };
+}
+
+it('renders correctly', () => {
+  const { props } = setup();
+  const tree = renderer.create(<BudgetItemDetail {...props} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('should render title and subtitle', () => {
+  const { enzymeWrapper } = setup();
+  expect(enzymeWrapper.find('h1').text()).toBe('Mock testing description');
+  expect(enzymeWrapper.find('h2').exists()).toBe(true);
+});
+
+it('should render subtitle percentage, sign and color correctly', () => {
+  const inflowWrapper = setup().enzymeWrapper;
+  expect(inflowWrapper.find('h2').text()).toBe('+33.33%');
+  expect(
+    inflowWrapper
+      .find('h2')
+      .find('span')
+      .hasClass(styles.income)
+  ).toBe(true);
+
+  const outflowWrapper = setup(true).enzymeWrapper;
+  expect(outflowWrapper.find('h2').text()).toBe('-33.33%');
+  expect(
+    outflowWrapper
+      .find('h2')
+      .find('span')
+      .hasClass(styles.outcome)
+  ).toBe(true);
+});
+
+it('should render a Pie Chart component', () => {
+  const { enzymeWrapper } = setup();
+  expect(enzymeWrapper.find('MockPieChart').exists()).toBe(true);
+});

--- a/app/components/BudgetItemDetail/index.js
+++ b/app/components/BudgetItemDetail/index.js
@@ -1,0 +1,50 @@
+// @flow
+import * as React from 'react';
+import type { Transaction } from 'modules/transactions';
+import PieChart from 'components/PieChart';
+
+import styles from './style.scss';
+
+type BudgetItemDetailProps = {
+  transaction: Transaction,
+  balance: number,
+};
+
+const BudgetItemDetail = ({ transaction, balance }: BudgetItemDetailProps) => {
+  const { value, description } = transaction;
+
+  const contribPercentage = value / balance * 100;
+  const remainingBalance = Math.abs(balance) - Math.abs(value);
+  const remainingPercentage = 100 - contribPercentage;
+
+  let isIncome = true;
+  if (value < 0) {
+    isIncome = false;
+  }
+
+  const data = [
+    {
+      categoryId: 'item',
+      category: `${contribPercentage.toFixed(2)}% - ${description}`,
+      value: Math.abs(value),
+    },
+    {
+      categoryId: 'total',
+      category: `${remainingPercentage.toFixed(2)}% - Other ${isIncome ? 'incomes' : 'outcomes'}`,
+      value: Math.abs(remainingBalance),
+    },
+  ];
+
+  return (
+    <div className={styles.budgetItemDetail}>
+      <h1>{transaction.description}</h1>
+      <h2>
+        <span className={isIncome ? styles.income : styles.outcome}>{isIncome ? '+' : '-'}</span>
+        {contribPercentage.toFixed(2)}%
+      </h2>
+      <PieChart data={data} dataLabel="category" dataKey="categoryId" />
+    </div>
+  );
+};
+
+export default BudgetItemDetail;

--- a/app/components/BudgetItemDetail/index.js
+++ b/app/components/BudgetItemDetail/index.js
@@ -13,15 +13,18 @@ type BudgetItemDetailProps = {
 const BudgetItemDetail = ({ transaction, balance }: BudgetItemDetailProps) => {
   const { value, description } = transaction;
 
+  // Calculate the values considering positive and negative values.
   const contribPercentage = value / balance * 100;
   const remainingBalance = Math.abs(balance) - Math.abs(value);
   const remainingPercentage = 100 - contribPercentage;
 
+  // This flag will be handy to switch styles and signs.
   let isIncome = true;
   if (value < 0) {
     isIncome = false;
   }
 
+  // Create data that Pie Chart needs to render, this could be moved to a helper.
   const data = [
     {
       categoryId: 'item',

--- a/app/components/BudgetItemDetail/index.js
+++ b/app/components/BudgetItemDetail/index.js
@@ -19,10 +19,7 @@ const BudgetItemDetail = ({ transaction, balance }: BudgetItemDetailProps) => {
   const remainingPercentage = 100 - contribPercentage;
 
   // This flag will be handy to switch styles and signs.
-  let isIncome = true;
-  if (value < 0) {
-    isIncome = false;
-  }
+  const isIncome = value >= 0;
 
   // Create data that Pie Chart needs to render, this could be moved to a helper.
   const data = [

--- a/app/components/BudgetItemDetail/style.scss
+++ b/app/components/BudgetItemDetail/style.scss
@@ -1,0 +1,32 @@
+@import 'theme/variables';
+
+.budgetItemDetail {
+  margin: 5px;
+
+  h1 {
+    font-size: 2em;
+    margin-bottom: 0px;
+  }
+  h2 {
+    font-size: 1.7em;
+    margin-top: 0px;
+  }
+
+
+  @media only screen and (max-width: $screen-small) {
+    h1, h2 {
+      text-align: center;
+    }
+  }
+
+}
+
+.income {
+  color:$green;
+  font-size: 1.1em;
+}
+
+.outcome {
+  color:$red;
+  font-size: 1.1em;
+}

--- a/app/components/PieChart/Path.js
+++ b/app/components/PieChart/Path.js
@@ -1,0 +1,44 @@
+// @flow
+import * as React from 'react';
+import { select, interpolate } from 'd3';
+
+type PathProps = {
+  data: Object,
+  fill: string,
+  arcFn: any,
+  animDuration: number,
+};
+
+class Path extends React.Component<PathProps> {
+  static defaultProps = {
+    animDuration: 1000,
+  };
+
+  componentDidMount() {
+    const { data, arcFn, animDuration } = this.props;
+    const path = select(this.pathRef);
+    const interpolateArc = interpolate(
+      { startAngle: 0, endAngle: 0 },
+      { startAngle: data.startAngle, endAngle: data.endAngle }
+    );
+
+    path
+      .transition()
+      .duration(animDuration)
+      .attrTween('d', () => t => arcFn(interpolateArc(t)));
+  }
+
+  pathRef: ?HTMLElement;
+
+  handleRefUpdate = (ref: ?HTMLElement) => {
+    this.pathRef = ref;
+  };
+
+  render() {
+    const { data, arcFn, fill } = this.props;
+
+    return <path ref={this.handleRefUpdate} fill={fill} d={arcFn(data)} />;
+  }
+}
+
+export default Path;

--- a/app/components/PieChart/__tests__/Path-test.js
+++ b/app/components/PieChart/__tests__/Path-test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Path from '../Path';
+
+it('renders correctly', () => {
+  const tree = renderer
+    .create(
+      <Path
+        data={{
+          startAngle: 3,
+          endAngle: 4,
+        }}
+        fill="fill"
+        arcFn={() => 'test'}
+        animDuration={3}
+      />
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/PieChart/__tests__/__snapshots__/Path-test.js.snap
+++ b/app/components/PieChart/__tests__/__snapshots__/Path-test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<path
+  d="test"
+  fill="fill"
+/>
+`;

--- a/app/components/PieChart/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/PieChart/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="pieChart"
+>
+  <div
+    height={316}
+    padding={8}
+    transform="translate(150,150)"
+    width={316}
+  />
+  <div
+    color={[Function]}
+    data={Array []}
+    dataKey="test"
+    dataLabel="test"
+    dataValue="value"
+  />
+</div>
+`;

--- a/app/components/PieChart/__tests__/index-test.js
+++ b/app/components/PieChart/__tests__/index-test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import PieChart from '../';
+
+// mock nested components
+jest.mock('components/PieChart/Path');
+jest.mock('components/Chart', () => 'div');
+jest.mock('components/Legend', () => 'div');
+
+it('renders correctly', () => {
+  const tree = renderer.create(<PieChart dataLabel="test" dataKey="test" data={[]} />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/PieChart/index.js
+++ b/app/components/PieChart/index.js
@@ -1,0 +1,93 @@
+// @flow
+
+import * as React from 'react';
+import Legend from 'components/Legend';
+import Chart from 'components/Chart';
+import type { TransactionSummary } from 'selectors/transactions';
+import { arc, pie, scaleOrdinal, schemeCategory20 } from 'd3';
+import { shuffle } from 'utils/array';
+import Path from './Path';
+import styles from './styles.scss';
+
+const randomScheme = shuffle(schemeCategory20);
+
+type PieChartProps = {
+  data: TransactionSummary[],
+  dataLabel: string,
+  dataKey: string,
+  dataValue: string,
+  color: Function,
+  height: number,
+};
+
+class PieChart extends React.Component<PieChartProps> {
+  static defaultProps = {
+    color: scaleOrdinal(randomScheme),
+    height: 300,
+    dataValue: 'value',
+  };
+
+  componentWillMount() {
+    this.updateChartVariables();
+  }
+
+  componentWillReceiveProps(nextProps: PieChartProps) {
+    const { data, color, height } = nextProps;
+
+    const old = this.props;
+
+    if (old.data !== data || old.color !== color || old.height !== height) {
+      this.updateChartVariables();
+    }
+  }
+
+  getPathArc = () => {
+    const { height } = this.props;
+    return arc()
+      .innerRadius(0)
+      .outerRadius(height / 2);
+  };
+
+  chart: any;
+  pathArc: any;
+  colorFn: any;
+  outerRadius: number;
+  boxLength: number;
+  chartPadding = 8;
+
+  updateChartVariables = () => {
+    const { data, dataValue, color, height } = this.props;
+
+    this.chart = pie()
+      .value(d => d[dataValue])
+      .sort(null);
+    this.outerRadius = height / 2;
+    this.pathArc = this.getPathArc();
+    this.colorFn = color.domain && color.domain([0, data.length]);
+    this.boxLength = height + this.chartPadding * 2;
+  };
+
+  render() {
+    const { data, dataLabel, dataValue, dataKey } = this.props;
+    const { outerRadius, pathArc, colorFn, boxLength, chartPadding } = this;
+
+    return (
+      <div className={styles.pieChart}>
+        <Chart
+          width={boxLength}
+          height={boxLength}
+          padding={chartPadding}
+          transform={`translate(${outerRadius},${outerRadius})`}
+        >
+          {this.chart(data).map((datum, index) => (
+            <Path data={datum} index={index} fill={colorFn(index)} arcFn={pathArc} key={datum.data[dataKey]} />
+          ))}
+        </Chart>
+
+        <Legend color={colorFn} {...{ data, dataValue, dataLabel, dataKey }} />
+      </div>
+    );
+  }
+}
+
+export default PieChart;

--- a/app/components/PieChart/styles.scss
+++ b/app/components/PieChart/styles.scss
@@ -1,0 +1,7 @@
+.pieChart {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-content: flex-start;
+  flex-flow: wrap;
+}

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -6,6 +6,7 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
+import BudgetItem from 'routes/BudgetItem';
 import Reports from 'routes/Reports';
 import './style.scss';
 
@@ -15,7 +16,8 @@ const App = () => (
       <Header />
 
       <Switch>
-        <Route path="/budget" component={Budget} />
+        <Route path="/budget" component={Budget} exact />
+        <Route path="/budget/:id" component={BudgetItem} exact />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />
       </Switch>

--- a/app/containers/BudgetItem/__tests__/__snapshots__/index-test.js.snap
+++ b/app/containers/BudgetItem/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<section
+  className="budgetItem"
+>
+  <a
+    className="backButton"
+    href="/budget"
+    onClick={[Function]}
+  >
+    Back
+  </a>
+  <MockBudgetItemDetail
+    balance={100}
+    transaction={
+      Object {
+        "description": "Mock testing description",
+        "id": 1,
+        "value": 33.33,
+      }
+    }
+  />
+</section>
+`;

--- a/app/containers/BudgetItem/__tests__/index-test.js
+++ b/app/containers/BudgetItem/__tests__/index-test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { shallow } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+import { BudgetItemContainer } from '../index';
+
+// mock nested component
+jest.mock('components/BudgetItemDetail', () => 'MockBudgetItemDetail');
+
+function setup() {
+  const props = {
+    id: 1,
+    transaction: {
+      id: 1,
+      description: 'Mock testing description',
+      value: 33.33,
+    },
+    balance: 100,
+  };
+  const enzymeWrapper = shallow(<BudgetItemContainer {...props} />);
+
+  return {
+    props,
+    enzymeWrapper,
+  };
+}
+
+it('renders correctly', () => {
+  const { props } = setup();
+  const tree = renderer
+    .create(
+      <MemoryRouter initialEntries={['/budget/1']}>
+        <BudgetItemContainer {...props} />
+      </MemoryRouter>
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('should render a back button and the BudgetItemDetail component', () => {
+  const { enzymeWrapper } = setup();
+  expect(enzymeWrapper.find('MockBudgetItemDetail').exists()).toBe(true);
+  expect(enzymeWrapper.find('Link').exists()).toBe(true);
+});

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -1,0 +1,59 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { Link, Redirect } from 'react-router-dom';
+import { getTransactionById, getOutflowBalance, getInflowBalance } from 'selectors/transactions';
+import transactionReducer from 'modules/transactions';
+import { injectAsyncReducers } from 'store';
+import type { Transaction } from 'modules/transactions';
+import BudgetItemDetail from 'components/BudgetItemDetail';
+
+import styles from './style.scss';
+
+injectAsyncReducers({
+  transactions: transactionReducer,
+});
+
+type BudgetItemContainerProps = {
+  id: number, // eslint-disable-line react/no-unused-prop-types
+  transaction: Transaction,
+  balance: number,
+};
+
+export class BudgetItemContainer extends React.Component<BudgetItemContainerProps> {
+  static defaultProps = {
+    id: 0,
+    transaction: {},
+    balance: 0,
+  };
+
+  render() {
+    const { transaction, balance } = this.props;
+
+    // Handle cases when a non-existent transaction ID was set in the URL.
+    if (!transaction.value) {
+      return <Redirect to="/budget" />;
+    }
+
+    return (
+      <section className={styles.budgetItem}>
+        <Link to="/budget" className={styles.backButton}>
+          Back
+        </Link>
+        <BudgetItemDetail transaction={transaction} balance={balance} />
+      </section>
+    );
+  }
+}
+
+const mapStateToProps = (state, props) => {
+  const id = parseInt(props.id, 10);
+  const transaction = getTransactionById(state, id) || {};
+  const balance = transaction.value < 0 ? getOutflowBalance(state) : getInflowBalance(state);
+  return {
+    transaction,
+    balance,
+  };
+};
+
+export default connect(mapStateToProps)(BudgetItemContainer);

--- a/app/containers/BudgetItem/style.scss
+++ b/app/containers/BudgetItem/style.scss
@@ -1,0 +1,20 @@
+@import 'theme/variables';
+
+.budgetItem {
+  display: flex;
+  flex-flow: column;
+  flex: 1;
+  border-collapse: collapse;
+  font-size: 0.8em;
+}
+
+.backButton {
+  width: 3em;
+  padding: 5px;
+  margin: 5px;
+  border-radius: 6px;
+  font-size: 1.5em;
+  color: $gray;
+  border: 1px solid $gray;
+  text-decoration: none;
+}

--- a/app/routes/BudgetItem/index.js
+++ b/app/routes/BudgetItem/index.js
@@ -1,0 +1,18 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadBudgetItemContainer = () => import('containers/BudgetItem' /* webpackChunkName: "budgetitem" */);
+
+type BudgetItemProps = {
+  match: Object,
+};
+
+class BudgetItem extends Component<BudgetItemProps> {
+  render() {
+    const { match: { params: { id } } } = this.props;
+    return <Chunk load={loadBudgetItemContainer} id={id} />;
+  }
+}
+
+export default BudgetItem;

--- a/app/selectors/__tests__/transactions-test.js
+++ b/app/selectors/__tests__/transactions-test.js
@@ -1,6 +1,7 @@
 import {
   sortTransactions,
   getTransactions,
+  getTransactionById,
   getInflowBalance,
   getOutflowBalance,
   getFormattedBalance,
@@ -47,6 +48,26 @@ describe('getTransactions', () => {
     const expectedSelection = [];
 
     expect(getTransactions(state)).toEqual(expectedSelection);
+  });
+});
+
+describe('getTransactionById', () => {
+  const state = {
+    transactions: [
+      { id: 1, description: 'Item One' },
+      { id: 2, description: 'Item Two' },
+      { id: 3, description: 'Item Three' },
+    ],
+  };
+
+  it('should return the correct transaction finding by id', () => {
+    const expectedSelection = { id: 2, description: 'Item Two' };
+
+    expect(getTransactionById(state, 2)).toEqual(expectedSelection);
+  });
+
+  it('should return undefined if transaction does not exist', () => {
+    expect(getTransactionById(state, 4)).toEqual(null);
   });
 });
 

--- a/app/selectors/__tests__/transactions-test.js
+++ b/app/selectors/__tests__/transactions-test.js
@@ -66,7 +66,7 @@ describe('getTransactionById', () => {
     expect(getTransactionById(state, 2)).toEqual(expectedSelection);
   });
 
-  it('should return undefined if transaction does not exist', () => {
+  it('should return null if transaction does not exist', () => {
     expect(getTransactionById(state, 4)).toEqual(null);
   });
 });

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -39,6 +39,9 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
 
+export const getTransactionById = (state: State, id: number): Transaction =>
+  getTransactions(state).filter(transaction => transaction.id === id)[0] || null;
+
 const getInflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value > 0)
 );


### PR DESCRIPTION
## Proposed Changes

- Add links and hover effect to budget grid row.
- Add a page to see the detail of a transaction.
- Create a route to navigate to transactions using it's id.
- Create a Pie Chart component.

## User Story

Feature
As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items

Acceptance Criteria

- Given that I have added at least one item to the budgeting grid
- When I click on that item
- Then I want to see a new page with a title corresponding to the item details
- And route should be dynamic with item ID in it
- And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow
- And a pie chart showing how much of the entire budget this item is contributing with should be on that page
- And no other items from the budget should be on that pie chart
- And there should be a back button to return back to the previous route
- And the view should be mobile and desktop compatible

## Screenshots
### Grid changes
![budgeting app educational react app](https://user-images.githubusercontent.com/320417/38252117-bf0a5082-3729-11e8-82df-982825811cb3.png)

### Detail page (desktop)
![budgeting app educational react app2](https://user-images.githubusercontent.com/320417/38252122-c2f09ed6-3729-11e8-9717-b5f388e55200.png)

### Detail page (mobile)
![budgeting app educational react app3](https://user-images.githubusercontent.com/320417/38252129-c7333576-3729-11e8-9658-5977240e7ffb.png)


## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [x] Documentation written (Only in code and PR)
