### PR TITLE
ReactJS Challenge

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  className="row"
+  onClick={undefined}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -8,16 +8,17 @@ import styles from './style.scss';
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  onRowClick: Function,
 };
 
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, onRowClick }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
   return (
-    <tr key={id}>
+    <tr key={id} onClick={onRowClick} className={styles.row}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>

--- a/app/components/BudgetGridRow/style.scss
+++ b/app/components/BudgetGridRow/style.scss
@@ -1,5 +1,9 @@
 @import 'theme/variables';
 
+.row {
+  cursor: pointer;
+}
+
 .cellLabel {
   display: none;
 

--- a/app/components/BudgetItemDetails/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetItemDetails/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly when transaction does not exists 1`] = `
+<span>
+  Could not find the corresponding budget item
+</span>
+`;
+
+exports[`renders correctly when transaction exists with negative value 1`] = `
+<div
+  className="budgetItemDetails"
+>
+  <h1
+    className="budgetItemDetailsTitle"
+  >
+    simple transaction with negative value
+  </h1>
+  <p
+    className="budgetItemDetailsSubtitle neg"
+  >
+    -20.00% of $50.00 (outflow)
+  </p>
+</div>
+`;
+
+exports[`renders correctly when transaction exists with positive value 1`] = `
+<div
+  className="budgetItemDetails"
+>
+  <h1
+    className="budgetItemDetailsTitle"
+  >
+    simple transaction with positive value
+  </h1>
+  <p
+    className="budgetItemDetailsSubtitle pos"
+  >
+    +10.00% of $100.00 (inflow)
+  </p>
+</div>
+`;

--- a/app/components/BudgetItemDetails/__tests__/index-test.js
+++ b/app/components/BudgetItemDetails/__tests__/index-test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import BudgetItemDetails from '../';
+
+// mock nested component
+jest.mock('components/PieChart');
+
+it('renders correctly when transaction exists with negative value', () => {
+  const transaction = { value: -10, description: 'simple transaction with negative value', categoryId: 1 };
+  const tree = renderer
+    .create(<BudgetItemDetails transaction={transaction} inflowBalance={100} outflowBalance={50} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders correctly when transaction exists with positive value', () => {
+  const transaction = { value: 10, description: 'simple transaction with positive value', categoryId: 1 };
+  const tree = renderer
+    .create(<BudgetItemDetails transaction={transaction} inflowBalance={100} outflowBalance={50} />)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});
+
+it('renders correctly when transaction does not exists', () => {
+  const tree = renderer.create(<BudgetItemDetails />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/components/BudgetItemDetails/__tests__/index-test.js
+++ b/app/components/BudgetItemDetails/__tests__/index-test.js
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer';
 import BudgetItemDetails from '../';
 
 // mock nested component
-jest.mock('components/PieChart');
+jest.mock('components/DonutChart');
 
 it('renders correctly when transaction exists with negative value', () => {
   const transaction = { value: -10, description: 'simple transaction with negative value', categoryId: 1 };

--- a/app/components/BudgetItemDetails/index.js
+++ b/app/components/BudgetItemDetails/index.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import cx from 'classnames';
 import { formatPercentageAmount } from 'utils/formatAmount';
+import DonutChart from 'components/DonutChart';
 import styles from './style.scss';
 
 type BudgetItemProps = {
@@ -24,11 +25,27 @@ class BudgetItemDetails extends React.Component<BudgetItemProps> {
       [styles.pos]: !percentageAmount.isNegative,
     });
 
+    const categoryTotalBudget = percentageAmount.isNegative ? outflowBalance : inflowBalance;
+    const remainingBudget = categoryTotalBudget - Math.abs(transaction.value);
+
+    const chartData: Object[] = [
+      {
+        id: '0',
+        value: Math.abs(transaction.value),
+        description: transaction.description,
+      },
+      {
+        id: '1',
+        value: remainingBudget,
+        description: `Rest of the ${percentageAmount.isNegative ? 'Outflow' : 'Inflow'}`,
+      },
+    ];
     return (
       <div className={styles.budgetItemDetails}>
         <h1 className={styles.budgetItemDetailsTitle}>{transaction.description}</h1>
         <p className={subtitleClassname}>{percentageAmount.text}</p>
 
+        <DonutChart data={chartData} dataLabel="description" dataKey="id" innerRatio={0} />
       </div>
     );
   }

--- a/app/components/BudgetItemDetails/index.js
+++ b/app/components/BudgetItemDetails/index.js
@@ -1,0 +1,36 @@
+// @flow
+import * as React from 'react';
+import cx from 'classnames';
+import { formatPercentageAmount } from 'utils/formatAmount';
+import styles from './style.scss';
+
+type BudgetItemProps = {
+  transaction: Object,
+  inflowBalance: number,
+  outflowBalance: number,
+};
+
+class BudgetItemDetails extends React.Component<BudgetItemProps> {
+  render() {
+    const { transaction, inflowBalance, outflowBalance } = this.props;
+    if (!transaction) {
+      return <span>Could not find the corresponding budget item</span>;
+    }
+
+    const percentageAmount = formatPercentageAmount(transaction.value, inflowBalance, outflowBalance);
+
+    const subtitleClassname = cx([styles.budgetItemDetailsSubtitle], {
+      [styles.neg]: percentageAmount.isNegative,
+      [styles.pos]: !percentageAmount.isNegative,
+    });
+
+    return (
+      <div className={styles.budgetItemDetails}>
+        <h1 className={styles.budgetItemDetailsTitle}>{transaction.description}</h1>
+        <p className={subtitleClassname}>{percentageAmount.text}</p>
+
+      </div>
+    );
+  }
+}
+export default BudgetItemDetails;

--- a/app/components/BudgetItemDetails/style.scss
+++ b/app/components/BudgetItemDetails/style.scss
@@ -20,7 +20,11 @@
   }
 
   @media only screen and (max-width: $screen-small) {
-    margin: 0 auto;
+    .budgetItemDetailsTitle,
+    .budgetItemDetailsSubtitle {
+      display: flex;
+      justify-content: center;
+    }
   }
 
 }

--- a/app/components/BudgetItemDetails/style.scss
+++ b/app/components/BudgetItemDetails/style.scss
@@ -1,0 +1,25 @@
+@import 'theme/variables';
+
+.budgetItemDetails {
+
+  .budgetItemDetailsTitle {
+    font-size: 15px;
+    font-family: $font-default;
+  }
+
+  .budgetItemDetailsSubtitle {
+    font-family: $font-default;
+    &.neg {
+      color: $red;
+    }
+
+    &.pos {
+      color: $green;
+    }
+  }
+
+  @media only screen and (max-width: $screen-small) {
+    margin: 0 auto;
+  }
+
+}

--- a/app/components/BudgetItemDetails/style.scss
+++ b/app/components/BudgetItemDetails/style.scss
@@ -9,6 +9,7 @@
 
   .budgetItemDetailsSubtitle {
     font-family: $font-default;
+
     &.neg {
       color: $red;
     }

--- a/app/components/DonutChart/Path.js
+++ b/app/components/DonutChart/Path.js
@@ -28,9 +28,9 @@ class Path extends React.Component<PathProps> {
       .attrTween('d', () => t => arcFn(interpolateArc(t)));
   }
 
-  pathRef: ?HTMLElement;
+  pathRef: ?Element;
 
-  handleRefUpdate = (ref: ?HTMLElement) => {
+  handleRefUpdate = (ref: ?Element) => {
     this.pathRef = ref;
   };
 

--- a/app/components/DonutChart/Path.js
+++ b/app/components/DonutChart/Path.js
@@ -28,9 +28,9 @@ class Path extends React.Component<PathProps> {
       .attrTween('d', () => t => arcFn(interpolateArc(t)));
   }
 
-  pathRef: ?Element;
+  pathRef: ?React.ElementRef<any>;
 
-  handleRefUpdate = (ref: ?Element) => {
+  handleRefUpdate = (ref: ?React.ElementRef<any>) => {
     this.pathRef = ref;
   };
 

--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -12,7 +12,7 @@ import styles from './styles.scss';
 const randomScheme = shuffle(schemeCategory20);
 
 type DonutChartProps = {
-  data: TransactionSummary[],
+  data: TransactionSummary[] | Object[],
   dataLabel: string,
   dataKey: string,
   dataValue: string,
@@ -45,8 +45,9 @@ class DonutChart extends React.Component<DonutChartProps> {
 
   getPathArc = () => {
     const { height, innerRatio } = this.props;
+    const innerRadius = innerRatio === 0 ? 0 : height / innerRatio;
     return arc()
-      .innerRadius(height / innerRatio)
+      .innerRadius(innerRadius)
       .outerRadius(height / 2);
   };
 

--- a/app/components/StackedChart/Rect.js
+++ b/app/components/StackedChart/Rect.js
@@ -30,9 +30,9 @@ class Rect extends React.Component<RectProps> {
     }
   }
 
-  rectRef: ?Element;
+  rectRef: ?React.ElementRef<any>;
 
-  handleRefUpdate = (ref: ?Element) => {
+  handleRefUpdate = (ref: ?React.ElementRef<any>) => {
     this.rectRef = ref;
   };
 

--- a/app/components/StackedChart/Rect.js
+++ b/app/components/StackedChart/Rect.js
@@ -30,9 +30,9 @@ class Rect extends React.Component<RectProps> {
     }
   }
 
-  rectRef: ?HTMLElement;
+  rectRef: ?Element;
 
-  handleRefUpdate = (ref: ?HTMLElement) => {
+  handleRefUpdate = (ref: ?Element) => {
     this.rectRef = ref;
   };
 

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -6,6 +6,7 @@ import ErrorBoundary from 'components/ErrorBoundary';
 import AppError from 'components/AppError';
 import Header from 'components/Header';
 import Budget from 'routes/Budget';
+import BudgetItem from 'routes/BudgetItem';
 import Reports from 'routes/Reports';
 import './style.scss';
 
@@ -15,7 +16,8 @@ const App = () => (
       <Header />
 
       <Switch>
-        <Route path="/budget" component={Budget} />
+        <Route path="/budget" component={Budget} exact />
+        <Route path="/budget/:id" component={BudgetItem} />
         <Route path="/reports" component={Reports} />
         <Redirect to="/budget" />
       </Switch>

--- a/app/containers/Balance/index.js
+++ b/app/containers/Balance/index.js
@@ -27,7 +27,7 @@ class Balance extends React.Component<BalanceProps> {
   }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state): Object => ({
   balance: getFormattedBalance(state),
   inflow: getFormattedInflowBalance(state),
   outflow: getFormattedOutflowBalance(state),

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -44,7 +44,7 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
   }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state): Object => ({
   transactions: getTransactions(state),
   categories: getCategories(state),
 });

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { getTransactions } from 'selectors/transactions';
 import { getCategories } from 'selectors/categories';
@@ -11,12 +12,18 @@ import styles from './style.scss';
 type BudgetGridProps = {
   transactions: Transaction[],
   categories: Object,
+  history: Object,
 };
 
 export class BudgetGrid extends React.Component<BudgetGridProps> {
   static defaultProps = {
     transactions: [],
     categories: {},
+  };
+
+  handleOnRowClick = (transactionId): void => {
+    const { history } = this.props;
+    history.push(`/budget/${transactionId}`);
   };
 
   render() {
@@ -33,7 +40,14 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map((transaction: Transaction): React.Element<any> => (
-            <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
+            <BudgetGridRow
+              key={transaction.id}
+              transaction={transaction}
+              categories={categories}
+              onRowClick={() => {
+                this.handleOnRowClick(transaction.id);
+              }}
+            />
           ))}
         </tbody>
         <tfoot>
@@ -49,4 +63,4 @@ const mapStateToProps = (state): Object => ({
   categories: getCategories(state),
 });
 
-export default connect(mapStateToProps)(BudgetGrid);
+export default withRouter(connect(mapStateToProps)(BudgetGrid));

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -21,7 +21,7 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
     categories: {},
   };
 
-  handleOnRowClick = (transactionId): void => {
+  handleOnRowClick = (transactionId: number): void => {
     const { history } = this.props;
     history.push(`/budget/${transactionId}`);
   };

--- a/app/containers/BudgetItem/__tests__/__snapshots__/index-test.js.snap
+++ b/app/containers/BudgetItem/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<section>
+  <button
+    className="backButton"
+    onClick={[Function]}
+  >
+    Back
+  </button>
+</section>
+`;

--- a/app/containers/BudgetItem/__tests__/index-test.js
+++ b/app/containers/BudgetItem/__tests__/index-test.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { BudgetItem } from '../index';
+
+// mock nested component
+jest.mock('components/BudgetItemDetails');
+
+it('renders correctly', () => {
+  const tree = renderer.create(<BudgetItem />).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/app/containers/BudgetItem/index.js
+++ b/app/containers/BudgetItem/index.js
@@ -1,0 +1,50 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { getTransactionById, getInflowBalance, getOutflowBalance } from 'selectors/transactions';
+import transactionReducer from 'modules/transactions';
+import categoryReducer from 'modules/categories';
+import { injectAsyncReducers } from 'store';
+import BudgetItemDetails from 'components/BudgetItemDetails';
+import styles from './style.scss';
+
+// inject reducers that might not have been originally there
+injectAsyncReducers({
+  transactions: transactionReducer,
+  categories: categoryReducer,
+});
+
+type BudgetItemProps = {
+  transaction: Object,
+  inflowBalance: number,
+  outflowBalance: number,
+  history: Object,
+};
+
+export class BudgetItem extends React.Component<BudgetItemProps> {
+  handleGoBack = (): void => {
+    const { history } = this.props;
+    history.goBack();
+  };
+
+  render() {
+    const { transaction, inflowBalance, outflowBalance } = this.props;
+    return (
+      <section>
+        <button className={styles.backButton} onClick={this.handleGoBack}>
+          Back
+        </button>
+        <BudgetItemDetails transaction={transaction} inflowBalance={inflowBalance} outflowBalance={outflowBalance} />
+      </section>
+    );
+  }
+}
+
+const mapStateToProps = (state, props): Object => ({
+  transaction: getTransactionById(state, Number(props.match.params.id)),
+  inflowBalance: getInflowBalance(state),
+  outflowBalance: Math.abs(getOutflowBalance(state)),
+});
+
+export default withRouter(connect(mapStateToProps)(BudgetItem));

--- a/app/containers/BudgetItem/style.scss
+++ b/app/containers/BudgetItem/style.scss
@@ -1,0 +1,25 @@
+@import 'theme/variables';
+
+.backButton {
+  color: $black;
+  cursor: pointer;
+  font-weight: 700;
+  font-family: $font-default;
+  text-transform: uppercase;
+  background: $darkgray;
+  border-radius: 4px;
+  padding: .7em 1em;
+  text-decoration: none;
+  border: transparent;
+  width: 10%;
+
+  &:hover {
+    background: darkgray;
+  }
+
+  @media only screen and (max-width: $screen-small) {
+    width: 100%;
+  }
+}
+
+

--- a/app/containers/BudgetItem/style.scss
+++ b/app/containers/BudgetItem/style.scss
@@ -14,7 +14,7 @@
   width: 10%;
 
   &:hover {
-    background: darkgray;
+    background: $lightgray;
   }
 
   @media only screen and (max-width: $screen-small) {

--- a/app/containers/InflowOutflow/index.js
+++ b/app/containers/InflowOutflow/index.js
@@ -31,7 +31,7 @@ class InflowOutflow extends React.Component<InflowOutflowProps> {
   }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state): Object => ({
   data: {
     inflow: sortTransactions(getInflowByCategoryName(state)),
     outflow: sortTransactions(getOutflowByCategoryName(state)),

--- a/app/containers/Spending/index.js
+++ b/app/containers/Spending/index.js
@@ -19,7 +19,7 @@ class Spending extends React.Component<SpendingProps> {
   }
 }
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state): Object => ({
   data: sortTransactions(getOutflowByCategoryName(state)),
 });
 

--- a/app/index.js
+++ b/app/index.js
@@ -17,7 +17,7 @@ const renderApp = (Component: React.ComponentType<any>) => {
         </AppContainer>
       </Router>
     </Provider>,
-    document.getElementById('root')
+    (document.getElementById('root'): any)
   );
 };
 

--- a/app/routes/BudgetItem/index.js
+++ b/app/routes/BudgetItem/index.js
@@ -1,0 +1,13 @@
+// @flow
+import React, { Component } from 'react';
+import Chunk from 'components/Chunk';
+
+const loadBudgetItem = () => import('containers/BudgetItem' /* webpackChunkName: "budgetItem" */);
+
+class BudgetItem extends Component<{}> {
+  render() {
+    return <Chunk load={loadBudgetItem} />;
+  }
+}
+
+export default BudgetItem;

--- a/app/selectors/__tests__/transactions-test.js
+++ b/app/selectors/__tests__/transactions-test.js
@@ -1,6 +1,7 @@
 import {
   sortTransactions,
   getTransactions,
+  getTransactionById,
   getInflowBalance,
   getOutflowBalance,
   getFormattedBalance,
@@ -47,6 +48,29 @@ describe('getTransactions', () => {
     const expectedSelection = [];
 
     expect(getTransactions(state)).toEqual(expectedSelection);
+  });
+});
+
+describe('getTransactionById', () => {
+  it('should return all transactions in the state', () => {
+    const state = { transactions: [{ id: 1 }, { id: 2 }] };
+    const expectedSelection = { id: 1 };
+
+    expect(getTransactionById(state, 1)).toEqual(expectedSelection);
+  });
+
+  it('should return undefined if the state transaction is not found', () => {
+    const state = { transactions: [{ id: 1 }, { id: 2 }] };
+    const expectedSelection = undefined;
+
+    expect(getTransactionById(state, 3)).toEqual(expectedSelection);
+  });
+
+  it('should return undefined if the state has no transactions', () => {
+    const state = {};
+    const expectedSelection = undefined;
+
+    expect(getTransactionById(state, 1)).toEqual(expectedSelection);
   });
 });
 

--- a/app/selectors/transactions.js
+++ b/app/selectors/transactions.js
@@ -39,6 +39,9 @@ const applyCategoryName = (transactions: TransactionSummary[], categories) =>
 
 export const getTransactions = (state: State): Transaction[] => state.transactions || [];
 
+export const getTransactionById = (state: State, transactionId: number): ?Transaction =>
+  getTransactions(state).find(transaction => transaction.id === transactionId);
+
 const getInflowTransactions = createSelector([getTransactions], transactions =>
   transactions.filter(item => item.value > 0)
 );

--- a/app/utils/__tests__/formatAmount-test.js
+++ b/app/utils/__tests__/formatAmount-test.js
@@ -1,0 +1,36 @@
+import formatAmount, { formatPercentageAmount } from '../formatAmount';
+
+describe('formatAmount', () => {
+  describe('when value is positive', () => {
+    it('should format the value to correct $ amount', () => {
+      const expected = { text: '$110.00', isNegative: false };
+      const actualValue = 110;
+      expect(formatAmount(actualValue)).toEqual(expected);
+    });
+
+    it('should format the value to correct percentage based on inflow', () => {
+      const inflow = 100;
+      const outflow = 50;
+      const actualValue = 10;
+
+      const expected = { text: '+10.00% of $100.00 (inflow)', isNegative: false };
+      expect(formatPercentageAmount(actualValue, inflow, outflow)).toEqual(expected);
+    });
+  });
+  describe('when value is negative', () => {
+    it('should format the value to correct $ amount', () => {
+      const expected = { text: '-$110.00', isNegative: true };
+      const actualValue = -110;
+      expect(formatAmount(actualValue)).toEqual(expected);
+    });
+
+    it('should format the value to correct percentage based on outflow', () => {
+      const inflow = 100;
+      const outflow = 50;
+      const actualValue = -10;
+
+      const expected = { text: '-20.00% of $50.00 (outflow)', isNegative: true };
+      expect(formatPercentageAmount(actualValue, inflow, outflow)).toEqual(expected);
+    });
+  });
+});

--- a/app/utils/formatAmount.js
+++ b/app/utils/formatAmount.js
@@ -17,3 +17,18 @@ export default function formatAmount(amount: number, showSign: boolean = true): 
     isNegative,
   };
 }
+
+export function formatPercentageAmount(amount: number, inflow: number, outflow: number): FormattedAmount {
+  const isNegative = amount < 0;
+  const totalValue = isNegative ? outflow : inflow;
+  const formatValue = (Math.abs(amount) / totalValue * 100).toFixed(2);
+
+  const totalValueText = isNegative
+    ? `${formatAmount(outflow).text} (outflow)`
+    : `${formatAmount(inflow).text} (inflow)`;
+
+  return {
+    text: `${isNegative ? '-' : '+'}${formatValue}% of ${totalValueText}`,
+    isNegative,
+  };
+}


### PR DESCRIPTION
## Proposed Changes

**Feature** 
As a user, I want to see percentage of total budget an item is contributing with, so I can better understand statistics of my inflow or outflow items 

**Acceptance Criteria** 
* Given that I have added at least one item to the budgeting grid **(done)**
* When I click on that item I want to see a new page with a title corresponding to the item details  **(done)**
* And route should be dynamic with item ID in it **(done)**
* And a subtitle under title should show percentage with red minus sign showing outflow, green plus sign for inflow **(clarified this and apparently we want percentage as item vs category so in our case percentage over total outflow / total inflow)** **(done)**
* And a pie chart showing how much of the entire budget this item is contributing with should be on that page  **(clarified this also and apparently we want the pie chart to show as item vs category so in our case the pie chart will contain item and the remaining of inflow/outflow that item is contribuing)** **(done)**
* And no other items from the budget should be on that pie chart **(done)**
* And there should be a back button to return back to the previous route  **(done)**
* And the view should be mobile and desktop compatible  **(done)**

## Screenshot
Large Screen
![screen shot 2018-05-23 at 10 19 28](https://user-images.githubusercontent.com/734986/40409228-d8c9fb74-5e72-11e8-9438-42bb02bd20b4.png)

Small Screen
![screen shot 2018-05-23 at 10 19 21](https://user-images.githubusercontent.com/734986/40409258-ec5a0fc6-5e72-11e8-894a-b0b882493796.png)


## Checklist

* [x] Feature developed
* [x] Created/updated unit tests


