### PR TITLE
Upgrade D3 to v5.5 and changed  schemeCategory10 instead of 20

### DIFF
--- a/app/components/DonutChart/index.js
+++ b/app/components/DonutChart/index.js
@@ -4,12 +4,12 @@ import * as React from 'react';
 import Legend from 'components/Legend';
 import Chart from 'components/Chart';
 import type { TransactionSummary } from 'selectors/transactions';
-import { arc, pie, scaleOrdinal, schemeCategory20 } from 'd3';
+import { arc, pie, scaleOrdinal, schemeCategory10 } from 'd3';
 import { shuffle } from 'utils/array';
 import Path from './Path';
 import styles from './styles.scss';
 
-const randomScheme = shuffle(schemeCategory20);
+const randomScheme = shuffle(schemeCategory10);
 
 type DonutChartProps = {
   data: TransactionSummary[],

--- a/app/components/StackedChart/index.js
+++ b/app/components/StackedChart/index.js
@@ -3,13 +3,13 @@ import * as React from 'react';
 import type { TransactionSummary } from 'selectors/transactions';
 import Legend from 'components/Legend';
 import Chart from 'components/Chart';
-import { max, scaleBand, scaleLinear, scaleOrdinal, schemeCategory20 } from 'd3';
+import { max, scaleBand, scaleLinear, scaleOrdinal, schemeCategory10 } from 'd3';
 import { shuffle } from 'utils/array';
 import Bar from './Bar';
 import Xaxis from './Xaxis';
 import styles from './styles.scss';
 
-const outflowScheme = shuffle([...schemeCategory20.slice(0, 4), ...schemeCategory20.slice(5)]);
+const outflowScheme = shuffle([...schemeCategory10.slice(0, 2), ...schemeCategory10.slice(3)]);
 const inflowScheme = ['#2ca02c']; // inflow always green
 
 type StackedChartProps = {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "cache-loader": "^1.0.3",
     "classnames": "^2.2.5",
     "coveralls": "^2.13.1",
-    "d3": "4.10.2",
+    "d3": "^5.5.0",
     "prop-types": "^15.5.10",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",


### PR DESCRIPTION
## Proposed Changes

Upgraded D3 from `4.10.2` to `5.5.0`.

The only major change was replacing `schemeCategory20` to `schemeCategory10` See https://github.com/d3/d3/blob/master/CHANGES.md#changes-in-d3-50

## Screenshot
#### Inflow-Outflow Chart Using schemeCategory10
<img width="896" alt="inflow-outflow-chart" src="https://user-images.githubusercontent.com/1232725/41801001-b2c679ba-763d-11e8-9161-2f73e0342f6e.png">

#### Donut Chart Using schemeCategory10
<img width="912" alt="donut-chart" src="https://user-images.githubusercontent.com/1232725/41801004-b6fc2458-763d-11e8-8f7a-569baafa4905.png">


## Checklist

* [x] Feature developed
* [ ] Created/updated unit tests
* [ ] Comments in code
* [ ] Documentation written
