### PR TITLE
Set prettier to add trailing commas

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "es5"
+}


### PR DESCRIPTION
## Proposed Changes

`eslint` config requires trailing commas, while `prettier` is not set up to add them automatically.
Added `prettierrc` with a setting to add trailing commas.

## Checklist

* [x] Feature developed
* [ ] Created/updated unit tests
* [ ] Comments in code
* [ ] Documentation written
