### PR TITLE
Add edit and deletion of transactions

### DIFF
--- a/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
+++ b/app/components/BudgetGridRow/__tests__/__snapshots__/index-test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly 1`] = `
-<tr>
+<tr
+  onClick={[Function]}
+>
   <td>
     <div
       className="cellLabel"

--- a/app/components/BudgetGridRow/index.js
+++ b/app/components/BudgetGridRow/index.js
@@ -8,16 +8,16 @@ import styles from './style.scss';
 type BudgetGridRowProps = {
   transaction: Transaction,
   categories: Categories,
+  setEditTransaction: Function,
 };
-
-const BudgetGridRow = ({ transaction, categories }: BudgetGridRowProps) => {
+const BudgetGridRow = ({ transaction, categories, setEditTransaction }: BudgetGridRowProps) => {
   const amount = formatAmount(transaction.value);
   const amountCls = amount.isNegative ? styles.neg : styles.pos;
   const { id, categoryId, description } = transaction;
   const category = categories[categoryId];
 
   return (
-    <tr key={id}>
+    <tr key={id} onClick={() => setEditTransaction(id)}>
       <td>
         <div className={styles.cellLabel}>Category</div>
         <div className={styles.cellContent}>{category}</div>

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -22,6 +22,23 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
     this.setState({ editTransactionId: id });
   };
 
+  getRowContent = (transaction, categories) =>
+    transaction.id === this.state.editTransactionId ? (
+      <EntryFormRow
+        key={transaction.id}
+        transaction={transaction}
+        categories={categories}
+        setEditTransaction={this.editTransaction}
+      />
+    ) : (
+      <BudgetGridRow
+        key={transaction.id}
+        transaction={transaction}
+        categories={categories}
+        setEditTransaction={this.editTransaction}
+      />
+    );
+
   render() {
     const { transactions, categories } = this.props;
 
@@ -36,22 +53,7 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map(
-            (transaction: Transaction): React.Element<any> =>
-              transaction.id === this.state.editTransactionId ? (
-                <EntryFormRow
-                  key={transaction.id}
-                  transaction={transaction}
-                  categories={categories}
-                  setEditTransaction={this.editTransaction}
-                />
-              ) : (
-                <BudgetGridRow
-                  key={transaction.id}
-                  transaction={transaction}
-                  categories={categories}
-                  setEditTransaction={this.editTransaction}
-                />
-              )
+            (transaction: Transaction): React.Element<any> => this.getRowContent(transaction, categories)
           )}
         </tbody>
         <tfoot>

--- a/app/containers/BudgetGrid/index.js
+++ b/app/containers/BudgetGrid/index.js
@@ -14,6 +14,14 @@ type BudgetGridProps = {
 };
 
 export class BudgetGrid extends React.Component<BudgetGridProps> {
+  state = {
+    editTransactionId: '',
+  };
+
+  editTransaction = (id: String) => {
+    this.setState({ editTransactionId: id });
+  };
+
   render() {
     const { transactions, categories } = this.props;
 
@@ -28,9 +36,22 @@ export class BudgetGrid extends React.Component<BudgetGridProps> {
         </thead>
         <tbody>
           {transactions.map(
-            (transaction: Transaction): React.Element<any> => (
-              <BudgetGridRow key={transaction.id} transaction={transaction} categories={categories} />
-            )
+            (transaction: Transaction): React.Element<any> =>
+              transaction.id === this.state.editTransactionId ? (
+                <EntryFormRow
+                  key={transaction.id}
+                  transaction={transaction}
+                  categories={categories}
+                  setEditTransaction={this.editTransaction}
+                />
+              ) : (
+                <BudgetGridRow
+                  key={transaction.id}
+                  transaction={transaction}
+                  categories={categories}
+                  setEditTransaction={this.editTransaction}
+                />
+              )
           )}
         </tbody>
         <tfoot>

--- a/app/containers/BudgetGrid/style.scss
+++ b/app/containers/BudgetGrid/style.scss
@@ -16,7 +16,8 @@
     padding: 8px;
   }
 
-  th, td {
+  th,
+  td {
     text-align: left;
     overflow: hidden;
 
@@ -24,7 +25,8 @@
       text-align: right;
     }
 
-    &:nth-child(1), &:nth-child(3) {
+    &:nth-child(1),
+    &:nth-child(3) {
       flex: 1;
       min-width: 120px;
     }
@@ -34,7 +36,8 @@
     }
   }
 
-  thead, tfoot {
+  thead,
+  tfoot {
     background-color: $verylightgray;
   }
 
@@ -49,6 +52,10 @@
 
     tr {
       border-bottom: 1px solid $lightgray;
+      &:hover {
+        cursor: pointer;
+        background-color: $verylightgray;
+      }
     }
 
     td {
@@ -63,7 +70,10 @@
   }
 
   @media only screen and (max-width: $screen-small) {
-    table, thead, tbody, tbody tr {
+    table,
+    thead,
+    tbody,
+    tbody tr {
       display: block;
     }
 

--- a/app/containers/BudgetGrid/style.scss
+++ b/app/containers/BudgetGrid/style.scss
@@ -65,7 +65,8 @@
   }
 
   tfoot {
-    height: 40px;
+    display: flex;
+    flex-wrap: nowrap;
     border-top: 1px solid $gray;
   }
 

--- a/app/containers/EntryFormRow/index.js
+++ b/app/containers/EntryFormRow/index.js
@@ -14,6 +14,7 @@ type EntryFormRowProps = {
   categories: Object,
   setEditTransaction: Function,
   addTransaction: Function,
+  deleteTransaction: Function,
   updateTransaction: Function,
 };
 
@@ -46,6 +47,11 @@ class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState>
       this.props.updateTransaction({ id, categoryId, description, value });
       this.props.setEditTransaction('');
     }
+  };
+
+  handleDelete = (id): void => {
+    this.props.setEditTransaction('');
+    this.props.deleteTransaction(id);
   };
 
   focusValueField = (): void => {
@@ -122,12 +128,25 @@ class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState>
                 handleRef={this.handleValueRefUpdate}
               />
               <Field component="input" name="id" type="hidden" value={id} />
-              <button type="submit" disabled={!isValid}>
+              <button className={`${styles.btn} ${styles.btnGreen}`} type="submit" disabled={!isValid}>
                 {!id ? 'Add' : 'Update'}
               </button>
               {id ? (
-                <button type="button" onClick={() => setEditTransaction('')}>
+                <button
+                  className={`${styles.btn} ${styles.btnDefault}`}
+                  type="button"
+                  onClick={() => setEditTransaction('')}
+                >
                   Cancel
+                </button>
+              ) : null}
+              {id ? (
+                <button
+                  className={`${styles.btn} ${styles.btnRed}`}
+                  type="button"
+                  onClick={() => this.handleDelete(id)}
+                >
+                  X
                 </button>
               ) : null}
             </div>
@@ -145,6 +164,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   addTransaction: actions.addTransaction,
+  deleteTransaction: actions.deleteTransaction,
   updateTransaction: actions.updateTransaction,
 };
 

--- a/app/containers/EntryFormRow/index.js
+++ b/app/containers/EntryFormRow/index.js
@@ -12,7 +12,9 @@ import styles from './style.scss';
 type EntryFormRowProps = {
   defaultCategoryId: string,
   categories: Object,
+  setEditTransaction: Function,
   addTransaction: Function,
+  updateTransaction: Function,
 };
 
 type EntryFormRowState = {
@@ -20,7 +22,7 @@ type EntryFormRowState = {
 };
 
 class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState> {
-  static formFields = ['categoryId', 'description', 'value'];
+  static formFields = ['id', 'categoryId', 'description', 'value'];
 
   static validateForm = ({ value }) => {
     const errors = {};
@@ -36,9 +38,14 @@ class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState>
     formData: null,
   };
 
-  addEntry = (values): void => {
-    const { categoryId, description, value } = values;
-    this.props.addTransaction({ categoryId, description, value });
+  handleSubmit = (values): void => {
+    const { id, categoryId, description, value } = values;
+    if (!id) {
+      this.props.addTransaction({ categoryId, description, value });
+    } else {
+      this.props.updateTransaction({ id, categoryId, description, value });
+      this.props.setEditTransaction('');
+    }
   };
 
   focusValueField = (): void => {
@@ -77,8 +84,14 @@ class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState>
   };
 
   render() {
-    const { categories, defaultCategoryId } = this.props;
-    const initialValues = { categoryId: defaultCategoryId };
+    const { categories, defaultCategoryId, transaction, setEditTransaction } = this.props;
+    const id = transaction ? transaction.id : '';
+    const initialValues = {
+      id,
+      categoryId: transaction ? transaction.categoryId : defaultCategoryId,
+      description: transaction ? transaction.description : '',
+      value: transaction ? transaction.value : '',
+    };
     const { formData } = this.state;
     const isValid = formData && formData.valid;
 
@@ -90,7 +103,7 @@ class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState>
             initialValues={initialValues}
             validate={EntryFormRow.validateForm}
             onFormDataChange={this.handleFormDataChange}
-            onSubmit={this.addEntry}
+            onSubmit={this.handleSubmit}
             onSubmitSuccess={this.handleSubmitSuccess}
             onSubmitFail={this.handleSubmitFail}
           >
@@ -108,9 +121,15 @@ class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState>
                 placeholder="Value"
                 handleRef={this.handleValueRefUpdate}
               />
+              <Field component="input" name="id" type="hidden" value={id} />
               <button type="submit" disabled={!isValid}>
-                Add
+                {!id ? 'Add' : 'Update'}
               </button>
+              {id ? (
+                <button type="button" onClick={() => setEditTransaction('')}>
+                  Cancel
+                </button>
+              ) : null}
             </div>
           </Form>
         </td>
@@ -126,6 +145,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   addTransaction: actions.addTransaction,
+  updateTransaction: actions.updateTransaction,
 };
 
 export default connect(

--- a/app/containers/EntryFormRow/index.js
+++ b/app/containers/EntryFormRow/index.js
@@ -148,7 +148,7 @@ class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState>
                   type="button"
                   onClick={() => this.handleDelete(id)}
                 >
-                  X
+                  Delete
                 </button>
               ) : null}
             </div>

--- a/app/containers/EntryFormRow/index.js
+++ b/app/containers/EntryFormRow/index.js
@@ -134,22 +134,22 @@ class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState>
                 {!id ? 'Add' : 'Update'}
               </button>
               {id ? (
-                <button
-                  className={`${styles.btn} ${styles.btnDefault}`}
-                  type="button"
-                  onClick={() => setEditTransaction('')}
-                >
-                  Cancel
-                </button>
-              ) : null}
-              {id ? (
-                <button
-                  className={`${styles.btn} ${styles.btnRed}`}
-                  type="button"
-                  onClick={() => this.handleDelete(id)}
-                >
-                  Delete
-                </button>
+                <>
+                  <button
+                    className={`${styles.btn} ${styles.btnDefault}`}
+                    type="button"
+                    onClick={() => setEditTransaction('')}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className={`${styles.btn} ${styles.btnRed}`}
+                    type="button"
+                    onClick={() => this.handleDelete(id)}
+                  >
+                    Delete
+                  </button>
+                </>
               ) : null}
             </div>
           </Form>

--- a/app/containers/EntryFormRow/index.js
+++ b/app/containers/EntryFormRow/index.js
@@ -127,6 +127,8 @@ class EntryFormRow extends React.Component<EntryFormRowProps, EntryFormRowState>
                 placeholder="Value"
                 handleRef={this.handleValueRefUpdate}
               />
+            </div>
+            <div className={styles.formSection}>
               <Field component="input" name="id" type="hidden" value={id} />
               <button className={`${styles.btn} ${styles.btnGreen}`} type="submit" disabled={!isValid}>
                 {!id ? 'Add' : 'Update'}

--- a/app/containers/EntryFormRow/style.scss
+++ b/app/containers/EntryFormRow/style.scss
@@ -18,6 +18,7 @@
 
     form {
       display: flex;
+      flex-wrap: wrap;
       width: 100%;
     }
 
@@ -27,7 +28,6 @@
       min-width: 50px;
       height: 100%;
       font-size: 1.1em;
-
       padding: 0.5em 0.6em;
       display: inline-block;
       border: 1px solid #ccc;
@@ -53,6 +53,7 @@
       text-decoration: none;
       border: transparent;
       cursor: pointer;
+      height: 35px;
 
       &.btnDefault {
         @include btn-theme($mediumgray);

--- a/app/containers/EntryFormRow/style.scss
+++ b/app/containers/EntryFormRow/style.scss
@@ -1,3 +1,12 @@
+@import './../../theme/variables';
+
+@mixin btn-theme($btn-color) {
+  background-color: $btn-color;
+  &:hover {
+    background-color: darken($btn-color, 6%);
+  }
+}
+
 .entryFormRow {
   & {
     padding: 2px !important;
@@ -34,11 +43,10 @@
       margin: 0;
     }
 
-    button {
+    .btn {
       color: #fff;
       margin-left: 5px;
       text-transform: uppercase;
-      background: rgb(28, 184, 65);
       text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
       border-radius: 4px;
       padding: 0.5em 1em;
@@ -46,8 +54,20 @@
       border: transparent;
       cursor: pointer;
 
+      &.btnDefault {
+        @include btn-theme($mediumgray);
+      }
+
+      &.btnGreen {
+        @include btn-theme($green);
+      }
+
+      &.btnRed {
+        @include btn-theme($red);
+      }
+
       &:disabled {
-        background: darkgray;
+        @include btn-theme($gray);
         cursor: not-allowed;
       }
     }

--- a/app/containers/EntryFormRow/style.scss
+++ b/app/containers/EntryFormRow/style.scss
@@ -10,25 +10,26 @@
     form {
       display: flex;
       width: 100%;
-    };
+    }
 
-    input, select {
+    input,
+    select {
       flex: 1;
       min-width: 50px;
       height: 100%;
       font-size: 1.1em;
 
-      padding: .5em .6em;
+      padding: 0.5em 0.6em;
       display: inline-block;
       border: 1px solid #ccc;
-      box-shadow: inset 0 1px 3px rgba(50,50,50,.16);
+      box-shadow: inset 0 1px 3px rgba(50, 50, 50, 0.16);
       border-radius: 4px;
       vertical-align: middle;
       box-sizing: border-box;
     }
 
-    input[type=number]::-webkit-inner-spin-button,
-    input[type=number]::-webkit-outer-spin-button {
+    input[type='number']::-webkit-inner-spin-button,
+    input[type='number']::-webkit-outer-spin-button {
       -webkit-appearance: none;
       margin: 0;
     }
@@ -40,12 +41,14 @@
       background: rgb(28, 184, 65);
       text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
       border-radius: 4px;
-      padding: .5em 1em;
+      padding: 0.5em 1em;
       text-decoration: none;
       border: transparent;
+      cursor: pointer;
 
       &:disabled {
         background: darkgray;
+        cursor: not-allowed;
       }
     }
   }
@@ -55,7 +58,8 @@
   display: flex;
   padding: 1px;
 
-  &:nth-child(1), &:nth-child(3) {
+  &:nth-child(1),
+  &:nth-child(3) {
     min-width: 120px;
     flex: 1;
   }

--- a/app/modules/__tests__/transactions-test.js
+++ b/app/modules/__tests__/transactions-test.js
@@ -118,8 +118,8 @@ describe('transactions module', () => {
       });
     });
 
-    describe('deleteTransaction', () => {
-      it('should create an action to update a transaction', async () => {
+    describe('updateTransaction', () => {
+      it('should create an action to update an existing transaction', async () => {
         await store.dispatch(actions.updateTransaction(outflowTransaction));
         expect(store.getActions()).toEqual([
           {

--- a/app/modules/__tests__/transactions-test.js
+++ b/app/modules/__tests__/transactions-test.js
@@ -120,13 +120,14 @@ describe('transactions module', () => {
 
     describe('updateTransaction', () => {
       it('should create an action to update an existing transaction', async () => {
-        await store.dispatch(actions.updateTransaction(outflowTransaction));
-        expect(store.getActions()).toEqual([
+        const expectedActions = [
           {
             type: 'budget/transaction/UPDATE',
             transaction: outflowTransaction,
           },
-        ]);
+        ];
+        await store.dispatch(actions.updateTransaction(outflowTransaction));
+        expect(store.getActions()).toEqual(expectedActions);
       });
     });
   });

--- a/app/modules/__tests__/transactions-test.js
+++ b/app/modules/__tests__/transactions-test.js
@@ -95,41 +95,38 @@ describe('transactions module', () => {
   describe('actions', () => {
     describe('addTransaction', () => {
       it('should create an action to add a transaction with the correct ID', async () => {
-        const expectedActions = [
+        await store.dispatch(actions.addTransaction(inflowTransaction));
+        expect(store.getActions()).toEqual([
           {
             type: 'budget/transaction/ADD',
             transaction: normalizedInflowTransaction,
           },
-        ];
-        await store.dispatch(actions.addTransaction(inflowTransaction));
-        expect(store.getActions()).toEqual(expectedActions);
+        ]);
       });
     });
 
     describe('deleteTransaction', () => {
       it('should create an action to delete a transaction', async () => {
         const id = 0;
-        const expectedAction = [
+        await store.dispatch(actions.deleteTransaction(id));
+        expect(store.getActions()).toEqual([
           {
             type: 'budget/transaction/DELETE',
             id,
           },
-        ];
-        await store.dispatch(actions.deleteTransaction(id));
-        expect(store.getActions()).toEqual(expectedAction);
+        ]);
       });
     });
 
     describe('deleteTransaction', () => {
       it('should create an action to update a transaction', async () => {
-        const expectedActions = [
+        await store.dispatch(actions.updateTransaction(outflowTransaction));
+        expect(store.getActions()).toEqual([
           {
             type: 'budget/transaction/UPDATE',
-            transaction: inflowTransaction,
+            transaction: outflowTransaction,
           },
-        ];
-        await store.dispatch(actions.updateTransaction(inflowTransaction));
-        expect(store.getActions()).toEqual(expectedActions);
+        ]);
       });
     });
   });

--- a/app/modules/__tests__/transactions-test.js
+++ b/app/modules/__tests__/transactions-test.js
@@ -1,13 +1,15 @@
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import transactionsReducer, { actions } from '../transactions';
+import transactionsReducer, { getNextTransactionID, normalizeTransaction, actions } from '../transactions';
 
-// Mock 'defaults' dependency to define a custom 'inflowCategories' and 'defaultTransactions'
+import { defaultTransactions, inflowCategories } from '../defaults';
+
+// Mock default state
 jest.mock('../defaults', () => ({
   inflowCategories: [2],
   defaultTransactions: [
     {
-      id: 1,
+      id: 0,
       description: "Trader Joe's food",
       value: -423.34,
       categoryId: 1,
@@ -19,336 +21,182 @@ jest.mock('../defaults', () => ({
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
 
-describe('actions', () => {
-  describe('addTransaction', () => {
-    it('should create an action to add a transaction', async () => {
-      const store = mockStore({ transactions: [] });
+// Create reusable transaction data - can't be used in mock() above because Babel hoists Jest
+const initialTransaction = {
+  id: 0,
+  description: "Trader Joe's food",
+  value: -423.34,
+  categoryId: 1,
+};
 
-      const newTransaction = {
-        description: "Trader Joe's food",
-        value: 423.34,
-        categoryId: 1,
-      };
+const updatedInitialTransaction = {
+  id: 0,
+  description: "Trader Joe's food return",
+  value: -123.45,
+  categoryId: 2,
+};
 
-      const expectedActions = [
-        {
-          type: 'budget/transaction/ADD',
-          transaction: {
-            id: 0,
-            description: "Trader Joe's food",
-            value: -423.34,
-            categoryId: 1,
-          },
-        },
-      ];
+const inflowTransaction = {
+  description: 'Inflow item',
+  value: -234.56,
+  categoryId: 2,
+};
 
-      await store.dispatch(actions.addTransaction(newTransaction));
+const normalizedInflowTransaction = {
+  id: 1, // initial store has one transaction with id 1, so this will be 0 + 1
+  description: 'Inflow item',
+  value: 234.56, // will be a positive number since our mock's inflowCategories contains categoryId of 2
+  categoryId: 2,
+};
 
-      expect(store.getActions()).toEqual(expectedActions);
-    });
+const outflowTransaction = {
+  description: 'Outflow item',
+  value: 123.45,
+  categoryId: 1,
+};
 
-    it('should create an action to add a transaction with the right ID', async () => {
-      const store = mockStore({ transactions: [{ id: 5 }, { id: 3 }] });
+const normalizedOutflowTransaction = {
+  id: 1, // initial store has one transaction with id 1, so this will be 0 + 1
+  description: 'Outflow item',
+  value: -123.45, // will be a negative number since our mock's inflowCategories contains categoryId of 2
+  categoryId: 1,
+};
 
-      const newTransaction = {
-        description: "Trader Joe's food",
-        value: 423.34,
-        categoryId: 1,
-      };
-
-      const expectedActions = [
-        {
-          type: 'budget/transaction/ADD',
-          transaction: {
-            // new transaction id should by 1 more than the largest one in store
-            id: 6,
-            description: "Trader Joe's food",
-            value: -423.34,
-            categoryId: 1,
-          },
-        },
-      ];
-
-      await store.dispatch(actions.addTransaction(newTransaction));
-
-      expect(store.getActions()).toEqual(expectedActions);
-    });
-
-    it('should create an action to add a transaction with the right value for inflow categories', async () => {
-      const store = mockStore({ transactions: [] });
-
-      const newTransaction = {
-        description: "Trader Joe's food",
-        value: 423.34,
-        categoryId: 2,
-      };
-
-      const expectedActions = [
-        {
-          type: 'budget/transaction/ADD',
-          transaction: {
-            id: 0,
-            description: "Trader Joe's food",
-            // value should be positive because the transaction is in an inflow category
-            value: 423.34,
-            categoryId: 2,
-          },
-        },
-      ];
-
-      await store.dispatch(actions.addTransaction(newTransaction));
-
-      expect(store.getActions()).toEqual(expectedActions);
+describe('transactions module', () => {
+  let store;
+  beforeEach(() => {
+    store = mockStore({
+      inflowCategories,
+      transactions: defaultTransactions,
     });
   });
 
-  describe('deleteTransaction', () => {
-    it('should create an action to delete a transaction', () => {
-      const id = 1;
-      const expectedAction = {
-        type: 'budget/transaction/DELETE',
-        id,
-      };
-      expect(actions.deleteTransaction(id)).toEqual(expectedAction);
+  describe('helpers', () => {
+    describe('getNextTransactionID', () => {
+      it('should get the next transaction id', () => {
+        expect(getNextTransactionID([])).toEqual(0);
+        expect(getNextTransactionID([{ id: 5 }, { id: 3 }])).toEqual(6);
+        expect(getNextTransactionID(store.getState().transactions)).toEqual(1);
+      });
+    });
+
+    describe('normalizeTransaction', () => {
+      it('should set value to positive when inflowCategories contains the categoryId, negative when it does not', () => {
+        expect(normalizeTransaction(store.getState().transactions, inflowTransaction)).toEqual(
+          normalizedInflowTransaction
+        );
+        expect(normalizeTransaction(store.getState().transactions, outflowTransaction)).toEqual(
+          normalizedOutflowTransaction
+        );
+      });
     });
   });
 
-  describe('updateTransaction', () => {
-    const store = mockStore({ transactions: [] });
-
-    it('should create an action to update a transaction', async () => {
-      const updatedTransaction = {
-        id: 0,
-        description: "Trader Joe's food",
-        value: -423.34,
-        categoryId: 1,
-      };
-
-      const expectedActions = [
-        {
-          type: 'budget/transaction/UPDATE',
-          transaction: {
-            id: 0,
-            description: "Trader Joe's food",
-            value: -423.34,
-            categoryId: 1,
-          },
-        },
-      ];
-
-      await store.dispatch(actions.updateTransaction(updatedTransaction));
-
-      expect(store.getActions()).toEqual(expectedActions);
-    });
-  });
-});
-
-describe('reducers', () => {
-  describe('transactionsReducer', () => {
-    it('should return the initial state', () => {
-      expect(transactionsReducer(undefined, {})).toEqual([
-        {
-          id: 1,
-          description: "Trader Joe's food",
-          value: -423.34,
-          categoryId: 1,
-        },
-      ]);
-    });
-
-    it('should handle addTransaction action', () => {
-      // test with empty state
-      expect(
-        transactionsReducer([], {
-          type: 'budget/transaction/ADD',
-          transaction: {
-            id: 0,
-            description: "Trader Joe's food",
-            value: -423.34,
-            categoryId: 1,
-          },
-        })
-      ).toEqual([
-        {
-          id: 0,
-          description: "Trader Joe's food",
-          value: -423.34,
-          categoryId: 1,
-        },
-      ]);
-
-      // test with non-empty state
-      expect(
-        transactionsReducer(
-          [
-            {
-              id: 0,
-              description: "Trader Joe's food",
-              value: -423.34,
-              categoryId: 1,
-            },
-          ],
+  describe('actions', () => {
+    describe('addTransaction', () => {
+      it('should create an action to add a transaction with the correct ID', async () => {
+        const expectedActions = [
           {
             type: 'budget/transaction/ADD',
-            transaction: {
-              id: 2,
-              description: 'Gas',
-              value: -764.73,
-              categoryId: 6,
-            },
-          }
-        )
-      ).toEqual([
-        {
-          id: 0,
-          description: "Trader Joe's food",
-          value: -423.34,
-          categoryId: 1,
-        },
-        {
-          id: 2,
-          description: 'Gas',
-          value: -764.73,
-          categoryId: 6,
-        },
-      ]);
+            transaction: normalizedInflowTransaction,
+          },
+        ];
+        await store.dispatch(actions.addTransaction(inflowTransaction));
+        expect(store.getActions()).toEqual(expectedActions);
+      });
     });
 
-    it('should handle deleteTransaction action', () => {
-      // test with empty state
-      expect(
-        transactionsReducer([], {
-          type: 'budget/transaction/DELETE',
-          id: 0,
-        })
-      ).toEqual([]);
-
-      // test with non-empty state
-      expect(
-        transactionsReducer(
-          [
-            {
-              id: 0,
-              description: "Trader Joe's food",
-              value: -423.34,
-              categoryId: 1,
-            },
-            {
-              id: 1,
-              description: 'Gas',
-              value: -764.73,
-              categoryId: 6,
-            },
-          ],
+    describe('deleteTransaction', () => {
+      it('should create an action to delete a transaction', async () => {
+        const id = 0;
+        const expectedAction = [
           {
             type: 'budget/transaction/DELETE',
-            id: 0,
-          }
-        )
-      ).toEqual([
-        {
-          id: 1,
-          description: 'Gas',
-          value: -764.73,
-          categoryId: 6,
-        },
-      ]);
+            id,
+          },
+        ];
+        await store.dispatch(actions.deleteTransaction(id));
+        expect(store.getActions()).toEqual(expectedAction);
+      });
     });
 
-    describe('updateTransaction', () => {
-      const store = mockStore({
-        transactions: [
+    describe('deleteTransaction', () => {
+      it('should create an action to update a transaction', async () => {
+        const expectedActions = [
           {
-            id: 0,
-            description: "Trader Joe's food",
-            value: -423.34,
-            categoryId: 1,
+            type: 'budget/transaction/UPDATE',
+            transaction: inflowTransaction,
           },
-        ],
+        ];
+        await store.dispatch(actions.updateTransaction(inflowTransaction));
+        expect(store.getActions()).toEqual(expectedActions);
+      });
+    });
+  });
+
+  describe('reducers', () => {
+    describe('transactionsReducer', () => {
+      it('should return the initial state', () => {
+        expect(transactionsReducer(undefined, {})).toEqual([initialTransaction]);
       });
 
-      it('should handle updateTransaction description and amount', () => {
-        expect(
-          transactionsReducer(
-            [
-              {
-                id: 0,
-                description: "Trader Joe's food",
-                value: -423.34,
-                categoryId: 1,
-              },
-              {
-                id: 1,
-                description: 'Some line item',
-                value: -123.45,
-                categoryId: 6,
-              },
-            ],
-            {
-              type: 'budget/transaction/UPDATE',
-              transaction: {
-                id: 1,
-                description: 'Some other line item!',
-                value: -234.56,
-                categoryId: 6,
-              },
-            }
-          )
-        ).toEqual([
-          {
-            id: 0,
-            description: "Trader Joe's food",
-            value: -423.34,
-            categoryId: 1,
-          },
-          {
-            id: 1,
-            description: 'Some other line item!',
-            value: -234.56,
-            categoryId: 6,
-          },
-        ]);
-      });
+      describe('addTransaction action', () => {
+        it('should add a transaction to empty state', () => {
+          expect(
+            transactionsReducer([], {
+              type: 'budget/transaction/ADD',
+              transaction: inflowTransaction,
+            })
+          ).toEqual([inflowTransaction]);
+        });
 
-      it('should handle updateTransaction category from inflow to outflow', async () => {
-        const updatedStore = await store.dispatch(
-          actions.updateTransaction({
-            id: 1,
-            description: 'Some inflow line item',
-            value: -423.34,
-            categoryId: 2,
-          })
-        );
-
-        expect(updatedStore).toEqual({
-          type: 'budget/transaction/UPDATE',
-          transaction: {
-            id: 1,
-            categoryId: 2,
-            description: 'Some inflow line item',
-            value: 423.34,
-          },
+        it('should add a transactions to non-empty state', () => {
+          expect(
+            transactionsReducer(store.getState().transactions, {
+              type: 'budget/transaction/ADD',
+              transaction: inflowTransaction,
+            })
+          ).toEqual([initialTransaction, inflowTransaction]);
         });
       });
 
-      it('should handle updateTransaction category from outflow to inflow', async () => {
-        const updatedStore = await store.dispatch(
-          actions.updateTransaction({
-            id: 1,
-            description: 'Some outflow line item',
-            value: 423.34,
-            categoryId: 1,
-          })
-        );
+      describe('deleteTransaction action', () => {
+        it('should do nothing when empty state', () => {
+          expect(
+            transactionsReducer([], {
+              type: 'budget/transaction/DELETE',
+              id: 1,
+            })
+          ).toEqual([]);
+        });
 
-        expect(updatedStore).toEqual({
-          type: 'budget/transaction/UPDATE',
-          transaction: {
-            id: 1,
-            categoryId: 1,
-            description: 'Some outflow line item',
-            value: -423.34,
-          },
+        it('should add delete a transaction from non-empty state', () => {
+          expect(
+            transactionsReducer([initialTransaction, normalizedInflowTransaction], {
+              type: 'budget/transaction/DELETE',
+              id: 0,
+            })
+          ).toEqual([normalizedInflowTransaction]);
+        });
+      });
+
+      describe('updateTransaction action', () => {
+        it('should update a specific transaction', async () => {
+          // Confirm description, value and categoryId were updated.
+          expect(
+            transactionsReducer([initialTransaction, normalizedInflowTransaction], {
+              type: 'budget/transaction/UPDATE',
+              transaction: updatedInitialTransaction,
+            })
+          ).toEqual([
+            {
+              id: 0,
+              description: "Trader Joe's food return",
+              value: -123.45,
+              categoryId: 2,
+            },
+            normalizedInflowTransaction,
+          ]);
         });
       });
     });

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -21,13 +21,6 @@ type UnindexedTransaction = {
   value: number,
 };
 
-type IndexedTransaction = {
-  id: string,
-  categoryId: string,
-  description: string,
-  value: number,
-};
-
 type Action = {
   type: string,
   transaction: Transaction,
@@ -41,27 +34,14 @@ function getNextTransactionID(state: Transaction[]): number {
   return state.reduce((maxId, todo) => Math.max(todo.id, maxId), -1) + 1;
 }
 
-// Add a new transaction.
 function normalizeTransaction(
   state: Transaction[],
-  { categoryId, description, value }: UnindexedTransaction
+  { id, categoryId, description, value }: UnindexedTransaction
 ): Transaction {
   const realValue = inflowCategories.includes(categoryId) ? Math.abs(value) : Math.abs(value) * -1;
 
   return {
-    id: getNextTransactionID(state),
-    categoryId,
-    description,
-    value: realValue,
-  };
-}
-
-// Add a new transaction.
-function normalizeExistingTransaction({ id, categoryId, description, value }: IndexedTransaction): Transaction {
-  const realValue = inflowCategories.includes(categoryId) ? Math.abs(value) : Math.abs(value) * -1;
-
-  return {
-    id,
+    id: id || getNextTransactionID(state),
     categoryId,
     description,
     value: realValue,
@@ -78,10 +58,10 @@ export const actions = {
       transaction: normalizeTransaction(getState().transactions, transaction),
     }),
 
-  updateTransaction: (transaction: IndexedTransaction) => (dispatch: Function) =>
+  updateTransaction: (transaction: Transaction) => (dispatch: Function, getState: Function) =>
     dispatch({
       type: UPDATE_TRANSACTION,
-      transaction: normalizeExistingTransaction(transaction),
+      transaction: normalizeTransaction(getState().transactions, transaction),
     }),
 
   deleteTransaction: (id: $PropertyType<Transaction, 'id'>) => ({

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -22,7 +22,7 @@ type UnindexedTransaction = {
 };
 
 type IndexedTransaction = {
-  id: String,
+  id: string,
   categoryId: string,
   description: string,
   value: number,

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -36,12 +36,12 @@ function getNextTransactionID(state: Transaction[]): number {
 
 function normalizeTransaction(
   state: Transaction[],
-  { id, categoryId, description, value }: UnindexedTransaction
+  { categoryId, description, value }: UnindexedTransaction
 ): Transaction {
   const realValue = inflowCategories.includes(categoryId) ? Math.abs(value) : Math.abs(value) * -1;
 
   return {
-    id: id || getNextTransactionID(state),
+    id: getNextTransactionID(state),
     categoryId,
     description,
     value: realValue,
@@ -58,10 +58,10 @@ export const actions = {
       transaction: normalizeTransaction(getState().transactions, transaction),
     }),
 
-  updateTransaction: (transaction: Transaction) => (dispatch: Function, getState: Function) =>
+  updateTransaction: (transaction: Transaction) => (dispatch: Function) =>
     dispatch({
       type: UPDATE_TRANSACTION,
-      transaction: normalizeTransaction(getState().transactions, transaction),
+      transaction,
     }),
 
   deleteTransaction: (id: $PropertyType<Transaction, 'id'>) => ({

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -30,11 +30,11 @@ type Action = {
 /**
  * Helpers
  */
-function getNextTransactionID(state: Transaction[]): number {
+export function getNextTransactionID(state: Transaction[]): number {
   return state.reduce((maxId, todo) => Math.max(todo.id, maxId), -1) + 1;
 }
 
-function normalizeTransaction(
+export function normalizeTransaction(
   state: Transaction[],
   { categoryId, description, value }: UnindexedTransaction
 ): Transaction {


### PR DESCRIPTION
## Proposed Changes

* Add mouseover effect to transaction line item
* Add click handler to transaction line item which opens form
* Add action/reducer for updating existing transaction
* Add delete button and ties in existing delete action/reducer
* Convert button style in EntryFormRow to class with mix-in to allow appropriate button colors
* Fixes truncation of add transaction form on narrow screen/phones.
* Add flew wrap to allow space for new buttons on narrower screens

## Screenshot

Wide screen
![image](https://user-images.githubusercontent.com/11415084/49463044-8104e600-f7c5-11e8-97b5-d00d6558d583.png)

Wraps properly now on narrow screen instead of cutting off desc, value and buttons:
![image](https://user-images.githubusercontent.com/11415084/49463058-882bf400-f7c5-11e8-9c59-16723475af5d.png)

## Checklist

* [x] Feature developed
* [x] Created/updated unit tests
* [x] Comments in code
* [ ] Documentation written
